### PR TITLE
fix: harden static site CSP and crawl surfaces

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/src/bitcoin_api/middleware.py
+++ b/src/bitcoin_api/middleware.py
@@ -151,6 +151,8 @@ def classify_client(user_agent: str) -> str:
     return "unknown"
 
 _DOCS_PATHS = {"/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json", "/admin/dashboard", "/admin/founder", "/visualizer"}
+_NOINDEX_PATHS = {"/docs", "/redoc", "/openapi.json", "/visualizer", "/x402"}
+_NOINDEX_PREFIXES = ("/history/block", "/history/tx", "/history/address")
 
 _PAGEVIEW_LOG_PATHS = {
     "/", "/docs", "/redoc", "/admin/dashboard", "/admin/founder",
@@ -261,8 +263,11 @@ def register_middleware(app: FastAPI):
         client_ip = get_client_ip(request)
         bucket = key_info.key_hash or client_ip
 
+        # --- Skip rate limiting for exempt internal keys (e.g. Kalshi bot) ---
+        _is_exempt = key_info.key_hash in settings.exempt_key_set
+
         # --- Skip rate limiting for registration (users must always be able to upgrade) ---
-        _skip_rate_limit = request.url.path == "/api/v1/register"
+        _skip_rate_limit = request.url.path == "/api/v1/register" or _is_exempt
 
         # --- Per-minute rate limit ---
         result = check_rate_limit(bucket, key_info.tier)
@@ -473,29 +478,43 @@ def register_middleware(app: FastAPI):
     @app.middleware("http")
     async def security_headers(request: Request, call_next):
         response = await call_next(request)
+        path = request.url.path
+        nonce = response.headers.get("X-CSP-Nonce")
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-        if request.url.path not in _DOCS_PATHS:
+        if path not in _DOCS_PATHS:
+            script_src = [
+                "'self'",
+                "'strict-dynamic'",
+                "https://us-assets.i.posthog.com",
+                "https://us.i.posthog.com",
+                "https://static.cloudflareinsights.com",
+            ]
+            if nonce:
+                script_src.append(f"'nonce-{nonce}'")
             response.headers["Content-Security-Policy"] = (
                 "default-src 'self'; "
-                "script-src 'self' 'strict-dynamic' https://us-assets.i.posthog.com https://us.i.posthog.com; "
+                f"script-src {' '.join(script_src)}; "
                 "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
                 "font-src 'self' https://fonts.gstatic.com; "
                 "img-src 'self' data: https://raw.githubusercontent.com; "
-                "connect-src 'self' https://bitcoinsapi.com https://us.i.posthog.com; "
+                "connect-src 'self' https://bitcoinsapi.com https://us.i.posthog.com https://cloudflareinsights.com; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "
                 "form-action 'self'"
             )
+        if "X-CSP-Nonce" in response.headers:
+            del response.headers["X-CSP-Nonce"]
+        if path in _NOINDEX_PATHS or any(path.startswith(prefix) for prefix in _NOINDEX_PREFIXES):
+            response.headers["X-Robots-Tag"] = "noindex, follow"
         if request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https":
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
         progress = get_sync_progress()
         if progress is not None and progress < 0.9999:
             response.headers["X-Node-Syncing"] = "true"
 
-        path = request.url.path
         if path.startswith("/api/v1/"):
             response.headers["X-Data-Disclaimer"] = "For informational purposes only. Not financial advice. See /terms"
         if "Cache-Control" not in response.headers:

--- a/src/bitcoin_api/static_routes.py
+++ b/src/bitcoin_api/static_routes.py
@@ -1,5 +1,6 @@
 """Static file routes: landing page, robots.txt, sitemap, decision pages, admin dashboard."""
 
+import re
 import secrets
 from pathlib import Path
 
@@ -25,12 +26,19 @@ def _render_html(path: Path) -> HTMLResponse | None:
     html = path.read_text(encoding="utf-8")
     ph_key = settings.posthog_api_key.get_secret_value() if settings.posthog_api_key else ""
     html = html.replace("__POSTHOG_API_KEY__", ph_key)
+    if '/static/js/site-helpers.js' not in html:
+        helper_tag = '<script src="/static/js/site-helpers.js"></script>'
+        html = re.sub(r"</body>", helper_tag + "\n</body>", html, count=1, flags=re.IGNORECASE)
+    nonce = secrets.token_urlsafe(16)
+    html = re.sub(r"<script(?![^>]*\bnonce=)", f'<script nonce="{nonce}"', html, flags=re.IGNORECASE)
 
     # Keep public navigation safe when the History Explorer is disabled.
     if not settings.enable_history_explorer:
         html = html.replace('href="/history"', 'href="/guide"')
 
-    return HTMLResponse(html)
+    response = HTMLResponse(html)
+    response.headers["X-CSP-Nonce"] = nonce
+    return response
 
 
 def _serve_404():
@@ -50,16 +58,18 @@ def register_static_routes(app: FastAPI):
     if _js_dir.is_dir():
         app.mount("/static/js", StaticFiles(directory=str(_js_dir)), name="static-js")
 
-    @app.get("/", include_in_schema=False)
+    _PUBLIC_METHODS = ["GET", "HEAD"]
+
+    @app.api_route("/", methods=_PUBLIC_METHODS, include_in_schema=False)
     def root():
         return _render_html(_LANDING_PAGE) or _serve_404()
 
-    @app.get("/api-docs", include_in_schema=False)
+    @app.api_route("/api-docs", methods=_PUBLIC_METHODS, include_in_schema=False)
     def api_docs_redirect():
         """Avoid maintaining a second docs surface; send users to live Swagger docs."""
-        return RedirectResponse(url="/docs", status_code=307)
+        return RedirectResponse(url="/docs", status_code=308)
 
-    @app.get("/.well-known/mcp/server-card.json", include_in_schema=False)
+    @app.api_route("/.well-known/mcp/server-card.json", methods=_PUBLIC_METHODS, include_in_schema=False)
     def mcp_server_card():
         """MCP server card for Smithery discovery."""
         p = _STATIC_DIR / ".well-known" / "mcp" / "server-card.json"
@@ -71,35 +81,35 @@ def register_static_routes(app: FastAPI):
             )
         return Response(status_code=404)
 
-    @app.get("/favicon.ico", include_in_schema=False)
+    @app.api_route("/favicon.ico", methods=_PUBLIC_METHODS, include_in_schema=False)
     def favicon():
         p = _STATIC_DIR / "favicon.ico"
         if p.exists():
             return Response(p.read_bytes(), media_type="image/x-icon")
         return Response(status_code=204)
 
-    @app.get("/robots.txt", include_in_schema=False)
+    @app.api_route("/robots.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def robots_txt():
         p = _STATIC_DIR / "robots.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return Response("User-agent: *\nAllow: /\n", media_type="text/plain")
 
-    @app.get("/llms.txt", include_in_schema=False)
+    @app.api_route("/llms.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def llms_txt():
         p = _STATIC_DIR / "llms.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return _serve_404()
 
-    @app.get("/llms-full.txt", include_in_schema=False)
+    @app.api_route("/llms-full.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def llms_full_txt():
         p = _STATIC_DIR / "llms-full.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return _serve_404()
 
-    @app.get("/sitemap.xml", include_in_schema=False)
+    @app.api_route("/sitemap.xml", methods=_PUBLIC_METHODS, include_in_schema=False)
     def sitemap_xml():
         p = _STATIC_DIR / "sitemap.xml"
         if p.exists():
@@ -108,7 +118,7 @@ def register_static_routes(app: FastAPI):
 
     _IMAGE_TYPES = {".png": "image/png", ".jpg": "image/jpeg", ".svg": "image/svg+xml", ".webp": "image/webp"}
 
-    @app.get("/{filename}.{ext}", include_in_schema=False)
+    @app.api_route("/{filename}.{ext}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def static_asset(filename: str, ext: str):
         """Serve static assets (images + IndexNow verification key) from the static directory."""
         # Prevent path traversal
@@ -180,7 +190,7 @@ def register_static_routes(app: FastAPI):
         """Process-alive check (no RPC call). Use for container healthchecks."""
         return {"status": "ok"}
 
-    @app.get("/history", include_in_schema=False)
+    @app.api_route("/history", methods=_PUBLIC_METHODS, include_in_schema=False)
     def history_index():
         """Serve the History Explorer index page (feature-flag gated)."""
         from .config import settings
@@ -189,7 +199,7 @@ def register_static_routes(app: FastAPI):
         p = _HISTORY_DIR / "index.html"
         return _render_html(p) or _serve_404()
 
-    @app.get("/history/{page}", include_in_schema=False)
+    @app.api_route("/history/{page}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def history_page(page: str):
         """Serve History Explorer sub-pages and static assets."""
         from .config import settings
@@ -210,9 +220,11 @@ def register_static_routes(app: FastAPI):
             return Response(resolved.read_text(encoding="utf-8"), media_type=media_types[resolved.suffix])
         return _serve_404()
 
-    @app.get("/{page}", include_in_schema=False)
+    @app.api_route("/{page}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def static_page(page: str):
         """Serve decision/comparison pages and IndexNow key from static directory."""
+        if page == "fee-observatory":
+            return RedirectResponse(url="/fees", status_code=308)
         allowed = {
             "vs-mempool", "vs-blockcypher", "best-bitcoin-api-for-developers",
             "bitcoin-api-for-ai-agents", "self-hosted-bitcoin-api",
@@ -221,7 +233,7 @@ def register_static_routes(app: FastAPI):
             "bitcoin-fee-estimator", "bitcoin-api-for-trading-bots",
             "how-to-reduce-bitcoin-transaction-fees",
             "terms", "privacy", "disclaimer", "visualizer", "pricing", "about", "guide",
-            "mcp-setup", "ai", "fees", "fee-observatory", "x402",
+            "mcp-setup", "ai", "fees", "x402",
         }
         if page in allowed:
             p = _STATIC_DIR / f"{page}.html"

--- a/static/fees.html
+++ b/static/fees.html
@@ -17,9 +17,6 @@
 <meta name="twitter:title" content="Bitcoin Fee Tracker — Live Rates & Send-or-Wait Verdicts">
 <meta name="twitter:description" content="Real-time Bitcoin fee tracker with send-or-wait verdicts. See current fees, congestion level, and how much you can save by waiting.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
 <script type="application/ld+json">
 {"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://bitcoinsapi.com/"},{"@type":"ListItem","position":2,"name":"Fee Tracker","item":"https://bitcoinsapi.com/fees"}]},{"@type":"WebApplication","@id":"https://bitcoinsapi.com/fees/#app","name":"Bitcoin Fee Tracker","description":"Real-time Bitcoin fee tracker with send-or-wait verdicts, congestion monitoring, and savings calculator.","url":"https://bitcoinsapi.com/fees","applicationCategory":"FinanceApplication","operatingSystem":"Web","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"publisher":{"@id":"https://bitcoinsapi.com/#organization"}}]}
@@ -78,10 +75,10 @@
     --green: #3fb950;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
   a { color: var(--blue); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+  code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
 
   /* Sync Warning Banner */
   .sync-banner { display: none; background: #D2992233; border-bottom: 1px solid #D29922; padding: 10px 24px; text-align: center; font-size: 0.9em; color: #D29922; position: sticky; top: 53px; z-index: 9; }
@@ -118,7 +115,7 @@
 
   /* Code block */
   .code-block { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; margin: 20px 0; overflow-x: auto; }
-  .code-block pre { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; color: var(--text); line-height: 1.6; white-space: pre; }
+  .code-block pre { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; font-size: 0.85em; color: var(--text); line-height: 1.6; white-space: pre; }
   .code-block .comment { color: var(--muted); }
   .code-block .cmd { color: var(--green); }
 
@@ -257,7 +254,7 @@
     font-size: 1.8em;
     font-weight: 700;
     color: var(--text);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace;
   }
   .stat-label {
     font-size: 0.8em;
@@ -290,7 +287,7 @@
   .savings-card .fee-amount {
     font-size: 1.4em;
     font-weight: 700;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace;
   }
   .savings-card .fee-usd {
     font-size: 0.9em;
@@ -342,7 +339,7 @@
 
 <nav style="background:#1a1a2e;padding:12px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100;flex-wrap:wrap;">
   <a href="/" style="color:#f7931a;font-weight:700;font-size:1.2rem;text-decoration:none;">Satoshi API</a>
-  <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Menu" style="display:none;background:none;border:1px solid #30363d;border-radius:4px;color:#8b949e;padding:6px 10px;cursor:pointer;font-size:1.2em;line-height:1;">&#9776;</button>
+  <button class="nav-toggle" data-nav-toggle=".nav-links" aria-label="Menu" style="display:none;background:none;border:1px solid #30363d;border-radius:4px;color:#8b949e;padding:6px 10px;cursor:pointer;font-size:1.2em;line-height:1;">&#9776;</button>
   <div class="nav-links" style="display:flex;gap:20px;align-items:center;">
     <a href="/" style="color:#ccc;text-decoration:none;">Home</a>
     <a href="/docs" style="color:#ccc;text-decoration:none;">Docs</a>
@@ -801,7 +798,19 @@ print(data["data"]["recommendation"], data["data"]["reasoning"])</pre>
     setText('refresh-counter', ago);
   }
 
+  function bindNavToggle() {
+    var toggle = document.querySelector('[data-nav-toggle]');
+    if (!toggle) return;
+    var targetSelector = toggle.getAttribute('data-nav-toggle');
+    var target = targetSelector ? document.querySelector(targetSelector) : null;
+    if (!target) return;
+    toggle.addEventListener('click', function() {
+      target.classList.toggle('open');
+    });
+  }
+
   /* ---- Init ---- */
+  bindNavToggle();
   refreshData();
   setInterval(refreshData, 30000);
   setInterval(updateCounter, 1000);

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -5,6 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bitcoin History Explorer — Satoshi API</title>
 <meta name="description" content="Explore Bitcoin's history from the genesis block to $100K. Interactive timeline with on-chain data, protocol concepts, and MCP tools.">
+<link rel="canonical" href="https://bitcoinsapi.com/history">
+<meta property="og:title" content="Bitcoin History Explorer â€” Satoshi API">
+<meta property="og:description" content="Explore Bitcoin's history from the genesis block to $100K with linked on-chain events, protocol context, and MCP tools.">
+<meta property="og:url" content="https://bitcoinsapi.com/history">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://bitcoinsapi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@BTCOrangeCoin">
+<meta name="twitter:title" content="Bitcoin History Explorer â€” Satoshi API">
+<meta name="twitter:description" content="Explore Bitcoin's history from the genesis block to $100K with linked on-chain events, protocol context, and MCP tools.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/static/index.html
+++ b/static/index.html
@@ -21,9 +21,6 @@
 <meta name="twitter:title" content="Satoshi API - Bitcoin Fee Intelligence for Apps and AI Agents">
 <meta name="twitter:description" content="Know when to send Bitcoin and when to wait. Live fee recommendations, mempool context, and transaction cost estimates for apps and AI agents.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {
     --bg: #000000;
@@ -53,10 +50,10 @@
     --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
   a { color: var(--accent); text-decoration: none; transition: color 0.2s var(--ease-out); }
   a:hover { color: var(--accent-hover); }
-  code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 8px; border-radius: 6px; font-size: 0.875em; }
+  code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 8px; border-radius: 6px; font-size: 0.875em; }
   pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 24px; overflow-x: auto; font-size: 0.875em; line-height: 1.7; }
   pre code { background: none; padding: 0; font-size: 1em; }
 
@@ -173,7 +170,7 @@
 
   /* Footer */
   footer { border-top: 1px solid var(--border); padding: 64px 24px; text-align: center; color: var(--muted); font-size: 0.85em; }
-  footer a { color: var(--dim); transition: color 0.2s var(--ease-out); }
+  footer a { color: var(--muted); transition: color 0.2s var(--ease-out); }
   footer a:hover { color: var(--text); }
 
   /* Subtle grain texture — low z-index so it never blocks content */
@@ -461,7 +458,7 @@
 
 <nav>
   <div class="logo"><img src="/logo-128.png" alt="Satoshi API" width="24" height="24" style="height:24px;vertical-align:middle;margin-right:8px;">SATOSHI API</div>
-  <button class="nav-toggle" onclick="document.querySelector('.links').classList.toggle('open')" aria-label="Menu">&#9776;</button>
+    <button class="nav-toggle" data-nav-toggle=".links" aria-label="Menu">&#9776;</button>
   <div class="links">
     <a href="#why-satoshi">Why Satoshi API</a>
     <a href="/bitcoin-fee-api">Fee API</a>
@@ -486,8 +483,8 @@
     <h1>Know the cheapest time to <span>send Bitcoin.</span></h1>
     <p class="subtitle">Satoshi API gives apps and AI agents live fee recommendations, mempool context, and transaction cost estimates so they can answer the only question that matters: send now or wait and save money.</p>
     <div class="cta">
-      <a href="/bitcoin-fee-api" class="btn-primary" onclick="posthog.capture('cta_click', {location:'hero',target:'fee_api'})">Check Live Fees</a>
-      <a href="#get-api-key" class="btn-secondary" onclick="posthog.capture('cta_click', {location:'hero',target:'get_api_key'})">Get Free API Key</a>
+      <a href="/bitcoin-fee-api" class="btn-primary" data-track-event="cta_click" data-track-location="hero" data-track-target="fee_api">Check Live Fees</a>
+      <a href="#get-api-key" class="btn-secondary" data-track-event="cta_click" data-track-location="hero" data-track-target="get_api_key">Get Free API Key</a>
     </div>
     <div class="hero-code">
 <pre><code><span style="color: var(--muted)">$ </span>pip install bitcoin-mcp</code></pre>
@@ -532,28 +529,28 @@
     <p class="section-subtitle">Copy any prompt below into Claude Desktop with <a href="https://github.com/Bortlesboat/bitcoin-mcp" target="_blank" rel="noopener noreferrer">bitcoin-mcp</a> installed. These are the highest-value workflows for first-time users.</p>
     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 48px;">
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="What's the current fee environment? Should I send a transaction now or wait for lower fees? How much would I save by waiting?">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="What's the current fee environment? Should I send a transaction now or wait for lower fees? How much would I save by waiting?">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Save Money</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Should I send Bitcoin right now?"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Get a send/wait recommendation with specific sat/vB rates and estimated savings if you wait.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Track this transaction and tell me when it's safe to consider confirmed: [paste your txid here]">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Track this transaction and tell me when it's safe to consider confirmed: [paste your txid here]">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Save Time</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Track this payment"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Paste a txid. Get confirmation count, fee rate, RBF status, and whether it'll make the next block.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Analyze the current mempool. How congested is it? What's the fee distribution? How many transactions are waiting?">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Analyze the current mempool. How congested is it? What's the fee distribution? How many transactions are waiting?">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Understand</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"What's happening in the mempool?"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Congestion level, fee buckets, next-block minimum fee, and total pending transactions.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Compare fee rates for different urgency levels. How much more does next-block confirmation cost vs. waiting an hour? Show me the exact cost in sats for a typical transaction.">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Compare fee rates for different urgency levels. How much more does next-block confirmation cost vs. waiting an hour? Show me the exact cost in sats for a typical transaction.">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Compare</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Compare urgency levels"</p>
@@ -562,7 +559,7 @@
 
     </div>
     <p style="text-align: center; margin-top: 32px;">
-      <a href="/bitcoin-api-for-ai-agents" style="font-weight: 600;" onclick="posthog.capture('cta_click', {location:'try_these', target:'ai_agents_page'})">See the AI agent setup guide &rarr;</a>
+      <a href="/bitcoin-api-for-ai-agents" style="font-weight: 600;" data-track-event="cta_click" data-track-location="try_these" data-track-target="ai_agents_page">See the AI agent setup guide &rarr;</a>
     </p>
   </div>
 </section>
@@ -673,7 +670,7 @@
 }</code></pre>
       </div>
     </div>
-    <p style="text-align: center; margin-top: 32px;"><a href="/docs" style="font-weight: 600;" onclick="posthog.capture('docs_click', {location:'see_it_work'})">Explore all endpoints &rarr;</a></p>
+    <p style="text-align: center; margin-top: 32px;"><a href="/docs" style="font-weight: 600;" data-track-event="docs_click" data-track-location="see_it_work">Explore all endpoints &rarr;</a></p>
   </div>
 </section>
 
@@ -805,7 +802,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
     <h3 id="get-api-key" style="margin-top: 48px; margin-bottom: 12px;">Option 2: Get a free API key (10x higher limits)</h3>
     <p style="color: var(--muted); margin-bottom: 16px;">Unlock 10,000 requests/day and POST access. Takes 5 seconds:</p>
     <div style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 28px; max-width: 480px;">
-      <form id="register-form" onsubmit="return handleRegister(event)">
+<form id="register-form">
         <div style="display: flex; gap: 8px; margin-bottom: 8px;">
           <input type="email" id="reg-email" placeholder="you@example.com" required
             style="flex: 1; padding: 12px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-visible); background: var(--surface-elevated); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; font-size: 0.95em; outline: none; transition: border-color 0.2s;"
@@ -852,7 +849,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>All GET endpoints + POST with key</li>
           <li>Always up-to-date</li>
         </ul>
-        <a href="#quickstart" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" onclick="posthog.capture('pricing_viewed', {tier:'hosted_free'})">Get Started</a>
+        <a href="#quickstart" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="hosted_free">Get Started</a>
       </div>
       <div class="price-card">
         <h3>Self-Hosted</h3>
@@ -864,7 +861,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>Full source code (Apache-2.0)</li>
           <li>Docker + pip install</li>
         </ul>
-        <a href="https://github.com/Bortlesboat/bitcoin-api" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" target="_blank" rel="noopener noreferrer" onclick="posthog.capture('pricing_viewed', {tier:'self_hosted'})">View on GitHub</a>
+        <a href="https://github.com/Bortlesboat/bitcoin-api" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" target="_blank" rel="noopener noreferrer" data-track-event="pricing_viewed" data-track-tier="self_hosted">View on GitHub</a>
       </div>
       <div class="price-card">
         <h3>Pay-per-call <span style="font-size: 0.7em; background: var(--accent); color: var(--bg); padding: 2px 8px; border-radius: 4px; vertical-align: middle;">x402</span></h3>
@@ -875,9 +872,9 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>AI analysis, tx broadcast</li>
           <li>Built for AI agents</li>
           <li>Standard HTTP 402 protocol</li>
-          <li>100+ endpoints remain free</li>
+          <li>109 endpoints remain free</li>
         </ul>
-        <a href="/api/v1/x402-demo" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" onclick="posthog.capture('pricing_viewed', {tier:'x402'})">Try the Demo</a>
+        <a href="/api/v1/x402-demo" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="x402">Try the Demo</a>
       </div>
     </div>
     <p style="color: var(--muted); text-align: center; margin-top: 24px; font-size: 0.9em;">Need higher hosted limits or a specific integration path? Contact <a href="mailto:api@bitcoinsapi.com">api@bitcoinsapi.com</a>.</p>
@@ -937,9 +934,9 @@ curl -H 'X-PAYMENT: demo' https://bitcoinsapi.com/api/v1/x402-demo</code></pre>
     <h2>Get a better Bitcoin fee decision in 60 seconds.</h2>
     <p>No signup, no install, no node. Check live fees now or plug the API into Claude via MCP.</p>
     <div class="cta" style="display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center;">
-      <a href="#quickstart" class="btn-primary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('cta_click', {location:'bottom',target:'quickstart'})">Get Started Free</a>
-      <a href="#get-api-key" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('cta_click', {location:'bottom',target:'get_api_key'})">Get Free API Key</a>
-      <a href="/docs" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('docs_click', {location:'bottom'})">Interactive Docs</a>
+      <a href="#quickstart" class="btn-primary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="cta_click" data-track-location="bottom" data-track-target="quickstart">Get Started Free</a>
+      <a href="#get-api-key" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="cta_click" data-track-location="bottom" data-track-target="get_api_key">Get Free API Key</a>
+      <a href="/docs" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="docs_click" data-track-location="bottom">Interactive Docs</a>
     </div>
     <p style="color: var(--muted); margin-top: 16px; font-size: 0.95em;">Want to be an early tester? <a href="https://github.com/Bortlesboat/bitcoin-api/issues" target="_blank" rel="noopener noreferrer">Open a GitHub issue</a> or join the <a href="https://discord.gg/EB6Jd66EsF" target="_blank" rel="noopener noreferrer">Discord community</a> and tell me what is missing, confusing, or broken.</p>
   </div>
@@ -1053,6 +1050,18 @@ function readStoredAttribution(key) {
 
 storeAttribution();
 
+function track(eventName, props) {
+  if (window.posthog && typeof window.posthog.capture === 'function') {
+    posthog.capture(eventName, props || {});
+  }
+}
+
+function identifyUser(id) {
+  if (window.posthog && typeof window.posthog.identify === 'function') {
+    posthog.identify(id);
+  }
+}
+
 /* API Key Registration */
 function handleRegister(e) {
   e.preventDefault();
@@ -1099,7 +1108,7 @@ function handleRegister(e) {
     if (firstTouch.utm_content) body.first_utm_content = firstTouch.utm_content;
   }
 
-  posthog.capture('registration_submitted', {
+  track('registration_submitted', {
     location: 'register_form',
     utm_source: body.utm_source || '',
     utm_medium: body.utm_medium || '',
@@ -1125,11 +1134,11 @@ function handleRegister(e) {
       if (window.crypto && window.crypto.subtle) {
         crypto.subtle.digest('SHA-256', new TextEncoder().encode(hashedEmail)).then(function(buf) {
           var hash = Array.from(new Uint8Array(buf)).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
-          posthog.identify(hash);
-          posthog.capture('registration_success', { tier: 'free' });
+          identifyUser(hash);
+          track('registration_success', { tier: 'free' });
         });
       } else {
-        posthog.capture('registration_success', { tier: 'free' });
+        track('registration_success', { tier: 'free' });
       }
       result.textContent = '';
       var wrapper = document.createElement('div');
@@ -1159,7 +1168,7 @@ function handleRegister(e) {
       result.appendChild(wrapper);
     } else {
       var msg = (res.data.error && res.data.error.detail) || res.data.detail || 'Registration failed. Try again.';
-      posthog.capture('registration_failed', { reason: msg });
+      track('registration_failed', { reason: msg });
       result.textContent = '';
       var errDiv = document.createElement('div');
       errDiv.style.cssText = 'color: #f85149; font-size: 0.9em;';
@@ -1171,7 +1180,7 @@ function handleRegister(e) {
     btn.disabled = false;
     btn.textContent = 'Get Key';
     result.style.display = 'block';
-    posthog.capture('registration_failed', { reason: 'network_error' });
+    track('registration_failed', { reason: 'network_error' });
     result.textContent = '';
     var netErr = document.createElement('div');
     netErr.style.cssText = 'color: #f85149; font-size: 0.9em;';
@@ -1226,10 +1235,60 @@ function copyPrompt(el) {
           hint.style.opacity = '0.6';
         }, 2000);
       }
-      posthog.capture('prompt_copied', { prompt: prompt.substring(0, 50) });
+      track('prompt_copied', { prompt: prompt.substring(0, 50) });
     });
   }
 }
+
+function bindNavToggle() {
+  var toggle = document.querySelector('[data-nav-toggle]');
+  if (!toggle) return;
+  var targetSelector = toggle.getAttribute('data-nav-toggle');
+  var target = targetSelector ? document.querySelector(targetSelector) : null;
+  if (!target) return;
+  toggle.addEventListener('click', function() {
+    target.classList.toggle('open');
+  });
+}
+
+function bindTrackedClicks() {
+  var tracked = document.querySelectorAll('[data-track-event]');
+  tracked.forEach(function(el) {
+    el.addEventListener('click', function() {
+      var props = {};
+      if (el.dataset.trackLocation) props.location = el.dataset.trackLocation;
+      if (el.dataset.trackTarget) props.target = el.dataset.trackTarget;
+      if (el.dataset.trackTier) props.tier = el.dataset.trackTier;
+      track(el.dataset.trackEvent, props);
+    });
+  });
+}
+
+function bindPromptCards() {
+  var promptCards = document.querySelectorAll('[data-prompt]');
+  promptCards.forEach(function(card) {
+    card.addEventListener('click', function() {
+      copyPrompt(card);
+    });
+    card.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        copyPrompt(card);
+      }
+    });
+  });
+}
+
+function bindRegistrationForm() {
+  var form = document.getElementById('register-form');
+  if (!form) return;
+  form.addEventListener('submit', handleRegister);
+}
+
+bindNavToggle();
+bindTrackedClicks();
+bindPromptCards();
+bindRegistrationForm();
 
 /* Scroll reveal with IntersectionObserver */
 (function() {

--- a/static/js/site-helpers.js
+++ b/static/js/site-helpers.js
@@ -1,0 +1,368 @@
+(function () {
+  function splitTopLevel(source) {
+    var tokens = [];
+    var current = "";
+    var quote = "";
+    var escape = false;
+
+    for (var i = 0; i < source.length; i += 1) {
+      var ch = source[i];
+
+      if (escape) {
+        current += ch;
+        escape = false;
+        continue;
+      }
+
+      if (quote) {
+        current += ch;
+        if (ch === "\\") {
+          escape = true;
+        } else if (ch === quote) {
+          quote = "";
+        }
+        continue;
+      }
+
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+
+      if (ch === "{" || ch === "}" || ch === "[" || ch === "]") {
+        return null;
+      }
+
+      if (ch === ",") {
+        tokens.push(current.trim());
+        current = "";
+        continue;
+      }
+
+      current += ch;
+    }
+
+    if (quote) {
+      return null;
+    }
+
+    if (current.trim() || source.trim() === "") {
+      tokens.push(current.trim());
+    }
+
+    return tokens.filter(function (token) {
+      return token.length > 0;
+    });
+  }
+
+  function unquote(token) {
+    if (token.length < 2) {
+      return token;
+    }
+
+    var quote = token[0];
+    var value = token.slice(1, -1);
+    if (quote === "'") {
+      return value.replace(/\\\\/g, "\\").replace(/\\'/g, "'").replace(/\\"/g, '"');
+    }
+
+    try {
+      return JSON.parse(token);
+    } catch (error) {
+      return value.replace(/\\\\/g, "\\").replace(/\\"/g, '"').replace(/\\'/g, "'");
+    }
+  }
+
+  function parseSimpleArgs(source) {
+    if (!source.trim()) {
+      return [];
+    }
+
+    var rawTokens = splitTopLevel(source);
+    if (!rawTokens) {
+      return null;
+    }
+
+    var tokens = [];
+    for (var i = 0; i < rawTokens.length; i += 1) {
+      var token = rawTokens[i];
+      if (!token) {
+        continue;
+      }
+      if (token === "this") {
+        tokens.push({ type: "self" });
+        continue;
+      }
+      if (token === "event") {
+        tokens.push({ type: "event" });
+        continue;
+      }
+      if (/^-?\d+$/.test(token)) {
+        tokens.push({ type: "number", value: Number(token) });
+        continue;
+      }
+      if (
+        (token[0] === "'" && token[token.length - 1] === "'") ||
+        (token[0] === '"' && token[token.length - 1] === '"')
+      ) {
+        tokens.push({ type: "string", value: unquote(token) });
+        continue;
+      }
+      return null;
+    }
+
+    return tokens;
+  }
+
+  function parseObjectLiteral(source) {
+    var pairs = splitTopLevel(source);
+    if (!pairs) {
+      return null;
+    }
+
+    var obj = {};
+    for (var i = 0; i < pairs.length; i += 1) {
+      var pair = pairs[i];
+      var index = pair.indexOf(":");
+      if (index === -1) {
+        return null;
+      }
+
+      var key = pair.slice(0, index).trim().replace(/^['"]|['"]$/g, "");
+      var valueToken = pair.slice(index + 1).trim();
+      if (!key) {
+        return null;
+      }
+
+      if (/^-?\d+$/.test(valueToken)) {
+        obj[key] = Number(valueToken);
+        continue;
+      }
+
+      if (
+        (valueToken[0] === "'" && valueToken[valueToken.length - 1] === "'") ||
+        (valueToken[0] === '"' && valueToken[valueToken.length - 1] === '"')
+      ) {
+        obj[key] = unquote(valueToken);
+        continue;
+      }
+
+      return null;
+    }
+
+    return obj;
+  }
+
+  function parseInvocation(rawCode) {
+    if (!rawCode) {
+      return null;
+    }
+
+    var code = rawCode.trim();
+    var preventDefault = false;
+
+    code = code.replace(/;?\s*return\s+false;?\s*$/i, function () {
+      preventDefault = true;
+      return "";
+    }).trim();
+
+    code = code.replace(/^return\s+/i, "");
+
+    var navMatch = code.match(
+      /^document\.querySelector\((['"])(.*?)\1\)\.classList\.toggle\((['"])(.*?)\3\);?$/i
+    );
+    if (navMatch) {
+      return {
+        type: "nav-toggle",
+        selector: navMatch[2],
+        className: navMatch[4],
+        preventDefault: preventDefault,
+      };
+    }
+
+    var posthogMatch = code.match(
+      /^posthog\.capture\((['"])(.*?)\1\s*,\s*\{([\s\S]*)\}\);?$/i
+    );
+    if (posthogMatch) {
+      var props = parseObjectLiteral(posthogMatch[3]);
+      if (props) {
+        return {
+          type: "posthog-capture",
+          eventName: posthogMatch[2],
+          props: props,
+          preventDefault: preventDefault,
+        };
+      }
+    }
+
+    var callMatch = code.match(/^([A-Za-z_$][\w$]*)\(([\s\S]*)\);?$/);
+    if (!callMatch) {
+      return null;
+    }
+
+    var args = parseSimpleArgs(callMatch[2]);
+    if (args === null) {
+      return null;
+    }
+
+    return {
+      type: "function-call",
+      name: callMatch[1],
+      args: args,
+      preventDefault: preventDefault,
+    };
+  }
+
+  function resolveArg(arg, element, event) {
+    if (arg.type === "self") {
+      return element;
+    }
+    if (arg.type === "event") {
+      return event;
+    }
+    return arg.value;
+  }
+
+  function invoke(parsed, element, event) {
+    if (!parsed) {
+      return undefined;
+    }
+
+    if (parsed.type === "nav-toggle") {
+      var target = document.querySelector(parsed.selector);
+      if (!target) {
+        return undefined;
+      }
+      var isOpen = !target.classList.contains(parsed.className);
+      target.classList.toggle(parsed.className);
+      if (element.hasAttribute("aria-expanded")) {
+        element.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      }
+      return undefined;
+    }
+
+    if (parsed.type === "posthog-capture") {
+      if (window.posthog && typeof window.posthog.capture === "function") {
+        window.posthog.capture(parsed.eventName, parsed.props);
+      }
+      return undefined;
+    }
+
+    var fn = window[parsed.name];
+    if (typeof fn !== "function") {
+      return undefined;
+    }
+
+    var args = parsed.args.map(function (arg) {
+      return resolveArg(arg, element, event);
+    });
+    return fn.apply(element, args);
+  }
+
+  function bindClick(element) {
+    if (!element || element.dataset.siteHelperClickBound === "true") {
+      return;
+    }
+
+    var raw = element.getAttribute("onclick");
+    if (!raw) {
+      return;
+    }
+
+    var parsed = parseInvocation(raw);
+    if (!parsed) {
+      return;
+    }
+
+    element.addEventListener("click", function (event) {
+      var href = element.getAttribute("href");
+      if (parsed.preventDefault || href === "#") {
+        event.preventDefault();
+      }
+
+      var result = invoke(parsed, element, event);
+      if (result === false) {
+        event.preventDefault();
+      }
+    });
+
+    element.removeAttribute("onclick");
+    element.dataset.siteHelperClickBound = "true";
+  }
+
+  function bindSubmit(form) {
+    if (!form || form.dataset.siteHelperSubmitBound === "true") {
+      return;
+    }
+
+    var raw = form.getAttribute("onsubmit");
+    if (!raw) {
+      return;
+    }
+
+    var parsed = parseInvocation(raw);
+    if (!parsed) {
+      return;
+    }
+
+    form.addEventListener("submit", function (event) {
+      var result = invoke(parsed, form, event);
+      if (parsed.preventDefault || result === false) {
+        event.preventDefault();
+      }
+    });
+
+    form.removeAttribute("onsubmit");
+    form.dataset.siteHelperSubmitBound = "true";
+  }
+
+  function collectTargets(root, selector) {
+    var targets = [];
+    if (!root) {
+      return targets;
+    }
+
+    if (root.nodeType === 1 && root.matches(selector)) {
+      targets.push(root);
+    }
+
+    if (root.querySelectorAll) {
+      var matches = root.querySelectorAll(selector);
+      for (var i = 0; i < matches.length; i += 1) {
+        targets.push(matches[i]);
+      }
+    }
+
+    return targets;
+  }
+
+  function processTree(root) {
+    collectTargets(root, "[onclick]").forEach(bindClick);
+    collectTargets(root, "form[onsubmit]").forEach(bindSubmit);
+  }
+
+  processTree(document);
+
+  if (document.documentElement && typeof MutationObserver === "function") {
+    var observer = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i += 1) {
+        var mutation = mutations[i];
+        if (mutation.type === "attributes") {
+          processTree(mutation.target);
+          continue;
+        }
+        for (var j = 0; j < mutation.addedNodes.length; j += 1) {
+          processTree(mutation.addedNodes[j]);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["onclick", "onsubmit"],
+    });
+  }
+})();

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -7,12 +7,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://bitcoinsapi.com/docs</loc>
-    <lastmod>2026-03-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://bitcoinsapi.com/vs-mempool</loc>
     <lastmod>2026-03-08</lastmod>
     <changefreq>monthly</changefreq>
@@ -59,12 +53,6 @@
     <lastmod>2026-03-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/visualizer</loc>
-    <lastmod>2026-03-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bitcoinsapi.com/terms</loc>
@@ -149,18 +137,6 @@
     <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/fee-observatory</loc>
-    <lastmod>2026-03-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/x402</loc>
-    <lastmod>2026-03-21</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bitcoinsapi.com/llms.txt</loc>

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -75,8 +75,14 @@ def test_docs_accessible(client):
 
 def test_api_docs_redirects_to_live_docs(client):
     resp = client.get("/api-docs", follow_redirects=False)
-    assert resp.status_code == 307
+    assert resp.status_code == 308
     assert resp.headers["location"] == "/docs"
+
+
+def test_fee_observatory_redirects_to_fees(client):
+    resp = client.get("/fee-observatory", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/fees"
 
 
 def test_envelope_format(client):
@@ -123,6 +129,84 @@ def test_root_csp_allows_configured_analytics_scripts(client):
     assert resp.status_code == 200
     csp = resp.headers["content-security-policy"]
     assert "https://us.i.posthog.com" in csp
+    assert "https://static.cloudflareinsights.com" in csp
+    assert "'nonce-" in csp
+    assert 'nonce="' in resp.text
+
+
+def test_core_marketing_pages_load_shared_site_helper(client):
+    for path in ["/", "/guide", "/pricing", "/mcp-setup", "/vs-mempool", "/history"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert '/static/js/site-helpers.js' in resp.text
+
+
+def test_shared_site_helper_asset_is_served(client):
+    resp = client.get("/static/js/site-helpers.js")
+    assert resp.status_code == 200
+    assert "processTree(document);" in resp.text
+
+
+def test_root_and_fee_tracker_drop_google_font_chain(client):
+    for path in ["/", "/fees"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "fonts.googleapis.com" not in resp.text
+        assert "fonts.gstatic.com" not in resp.text
+
+
+def test_root_register_form_no_longer_relies_on_inline_submit_handler(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert 'onsubmit=' not in resp.text
+
+
+def test_docs_surface_is_noindex(client):
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_visualizer_page_is_noindex(client):
+    resp = client.get("/visualizer")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_x402_page_is_noindex(client):
+    resp = client.get("/x402")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_history_index_has_canonical(client):
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    assert '<link rel="canonical" href="https://bitcoinsapi.com/history">' in resp.text
+
+
+def test_history_detail_pages_are_noindex(client):
+    for path in ["/history/block", "/history/tx", "/history/address"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_root_supports_head(client):
+    resp = client.head("/")
+    assert resp.status_code == 200
+
+
+def test_api_docs_supports_head_redirect(client):
+    resp = client.head("/api-docs", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/docs"
+
+
+def test_mcp_server_card_supports_head(client):
+    resp = client.head("/.well-known/mcp/server-card.json")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
 
 
 def test_health_deep(authed_client):

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -211,7 +211,7 @@ def test_503_when_db_missing(client):
 # --- Static page ---
 
 def test_fee_observatory_page(client):
-    """The /fee-observatory static page should serve."""
-    resp = client.get("/fee-observatory")
-    assert resp.status_code == 200
-    assert "Fee Observatory" in resp.text
+    """The legacy /fee-observatory route should redirect to the main fee tracker."""
+    resp = client.get("/fee-observatory", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/fees"


### PR DESCRIPTION
## Summary
- restore customer-facing static pages under strict CSP with nonce support and a shared helper for inline-handler replacements
- redirect thin or broken surfaces out of the crawl path and mark weak utility/detail pages as noindex
- add regression coverage for CSP, redirects, shared helper injection, and crawl-header behavior

## Validation
- python -m pytest tests/test_health.py tests/test_observatory.py -q with ENABLE_X402=false
- live production verification on https://bitcoinsapi.com/, /fees, /fee-observatory, /history, and /api/v1/fees/recommended

## Notes
- local Windows deployment shims, backups, and production-task wiring were intentionally kept out of this PR because they are machine-specific operational changes, not public repo code