### PR TITLE
Triage public site, x402 positioning, and agent discovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/docs/PUBLIC_SURFACE.md
+++ b/docs/PUBLIC_SURFACE.md
@@ -1,0 +1,138 @@
+# Public Surface Inventory
+
+Last updated: 2026-03-29
+
+This file is the operator-facing inventory of the live public product surface for `bitcoinsapi.com`.
+
+## Public website pages
+
+Primary hubs:
+- `/` - homepage and API key registration
+- `/fees` - live fee tracker and send-or-wait wedge
+- `/mcp-setup` - MCP setup guide
+- `/bitcoin-api-for-ai-agents` - AI agent landing page
+- `/x402` - x402 explainer plus live activity
+- `/pricing` - pricing and packaging
+- `/guide` - protocol guide
+- `/history` - history explorer hub
+
+Comparison and search pages:
+- `/vs-mempool`
+- `/vs-blockcypher`
+- `/best-bitcoin-api-for-developers`
+- `/self-hosted-bitcoin-api`
+- `/bitcoin-fee-api`
+- `/bitcoin-mempool-api`
+- `/bitcoin-mcp-setup-guide`
+- `/bitcoin-transaction-fee-calculator`
+- `/best-time-to-send-bitcoin`
+- `/bitcoin-fee-estimator`
+- `/bitcoin-api-for-trading-bots`
+- `/how-to-reduce-bitcoin-transaction-fees`
+
+Public utility and policy pages:
+- `/about`
+- `/terms`
+- `/privacy`
+- `/disclaimer`
+
+Noindex utility pages:
+- `/ai`
+- `/visualizer`
+- `/docs`
+- `/redoc`
+- `/openapi.json`
+- `/history/block`
+- `/history/tx`
+- `/history/address`
+
+Redirects:
+- `/api-docs` -> `/docs`
+- `/fee-observatory` -> `/fees`
+
+## Discovery assets for agents and crawlers
+
+- `/robots.txt`
+- `/sitemap.xml`
+- `/llms.txt`
+- `/llms-full.txt`
+- `/.well-known/mcp/server-card.json`
+- `/openapi.json`
+
+These should stay:
+- anonymously accessible
+- free of rate limiting
+- logged for discovery analytics
+
+## API surface by access mode
+
+Anonymous public endpoints:
+- `/api/v1/health`
+- `/api/v1/status`
+- `/api/v1/fees*`
+- `/api/v1/mempool*`
+- `/api/v1/blocks/latest`
+- `/api/v1/blocks/tip/*`
+- `/api/v1/blocks/{height_or_hash}`
+- `/api/v1/blocks/{height}/stats`
+- `/api/v1/tx/{txid}*`
+- `/api/v1/utxo/{txid}/{vout}`
+- `/api/v1/mining`
+- `/api/v1/mining/difficulty/history`
+- `/api/v1/network*`
+- `/api/v1/prices`
+- `/api/v1/market-data`
+- `/api/v1/supply`
+- `/api/v1/history/*`
+- `/api/v1/indexed/status`
+- `/api/v1/analytics/public`
+- `/api/v1/x402-info`
+- `/api/v1/x402-stats`
+
+API key required:
+- `/api/v1/health/deep`
+- `/api/v1/mining/pools`
+- `/api/v1/mining/revenue`
+- `/api/v1/mining/hashrate/history`
+- `/api/v1/stats/*`
+- `/api/v1/address/*`
+- `/api/v1/indexed/address/*`
+
+x402 premium lane:
+- `/api/v1/ai/*`
+- `/api/v1/mining/nextblock`
+- `/api/v1/fees/landscape`
+- `/api/v1/fees/observatory/*`
+- transaction broadcast route(s)
+
+Admin only:
+- `/api/v1/analytics/overview`
+- `/api/v1/analytics/founder`
+- `/admin/dashboard`
+- `/admin/founder`
+
+Streaming:
+- `/api/v1/stream/blocks`
+- `/api/v1/stream/fees`
+- `/api/v1/stream/whale-txs`
+
+## Smoke checks
+
+Core lightweight smoke test:
+- `scripts/smoke-test-api.sh`
+
+What it covers:
+- homepage
+- fee tracker
+- llms discovery file
+- x402 landing page
+- docs and OpenAPI
+- server card
+- public health, fee, mempool, difficulty, analytics
+- x402 demo and x402 info
+
+## Operating notes
+
+- Public static pages and discovery assets should never consume anonymous API rate budget.
+- AI crawler visibility depends on both `robots.txt` and the crawlability of `/llms.txt`, `/openapi.json`, and the MCP server card.
+- x402 should be treated as a premium lane inside the broader fee-intelligence product, not as a standalone business line.

--- a/docs/PUBLIC_SURFACE.md
+++ b/docs/PUBLIC_SURFACE.md
@@ -135,4 +135,5 @@ What it covers:
 
 - Public static pages and discovery assets should never consume anonymous API rate budget.
 - AI crawler visibility depends on both `robots.txt` and the crawlability of `/llms.txt`, `/openapi.json`, and the MCP server card.
+- The discovery docs (`/llms.txt`, `/llms-full.txt`, `/api/v1/guide`, and the MCP server card) must stay aligned with the real auth and x402 access model or agent adoption trust erodes quickly.
 - x402 should be treated as a premium lane inside the broader fee-intelligence product, not as a standalone business line.

--- a/scripts/smoke-test-api.sh
+++ b/scripts/smoke-test-api.sh
@@ -6,12 +6,11 @@
 
 set -uo pipefail
 
-BASE_URL="https://bitcoinsapi.com"
-TIMEOUT=10
+BASE_URL="${BASE_URL:-https://bitcoinsapi.com}"
+TIMEOUT="${TIMEOUT:-10}"
 QUIET=false
 PASS_COUNT=0
 FAIL_COUNT=0
-TOTAL=7
 
 [[ "${1:-}" == "--quiet" ]] && QUIET=true
 
@@ -20,21 +19,21 @@ check() {
     local url="$2"
     local pattern="${3:-}"
     local case_insensitive="${4:-false}"
+    local expected="${5:-200}"
 
     local http_code body
-    body=$(curl -s --max-time "$TIMEOUT" -w '\n%{http_code}' "$url" 2>/dev/null) || {
+    body=$(curl -s --max-time "$TIMEOUT" -H 'User-Agent: Mozilla/5.0' -w '\n%{http_code}' "$url" 2>/dev/null) || {
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        echo "FAIL  $name — curl error (timeout or connection refused)"
+        echo "FAIL  $name - curl error (timeout or connection refused)"
         return
     }
 
     http_code=$(echo "$body" | tail -1)
     body=$(echo "$body" | sed '$d')
 
-    local expected="${5:-200}"
     if [[ "$http_code" != "$expected" ]]; then
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        echo "FAIL  $name — HTTP $http_code (expected $expected)"
+        echo "FAIL  $name - HTTP $http_code (expected $expected)"
         return
     fi
 
@@ -44,7 +43,7 @@ check() {
 
         if ! echo "$body" | grep $grep_flags "$pattern"; then
             FAIL_COUNT=$((FAIL_COUNT + 1))
-            echo "FAIL  $name — response missing pattern: $pattern"
+            echo "FAIL  $name - response missing pattern: $pattern"
             return
         fi
     fi
@@ -53,15 +52,23 @@ check() {
     [[ "$QUIET" == "false" ]] && echo "PASS  $name"
 }
 
-check "health"         "$BASE_URL/api/v1/health"           '"status":"ok"'
-check "fees"           "$BASE_URL/api/v1/fees/recommended"  '"recommendation"'
-check "docs"           "$BASE_URL/docs"                     "swagger"          true
-check "openapi.json"   "$BASE_URL/openapi.json"             '"openapi"'
-check "redoc"          "$BASE_URL/redoc"
-check "x402-demo"      "$BASE_URL/api/v1/x402-demo"   '"Payment Required"' false 402
-check "x402-info"      "$BASE_URL/api/v1/x402-info"    '"x402"'
+check "home"         "$BASE_URL/"                                 "Satoshi API"                             true
+check "fees-page"    "$BASE_URL/fees"                             "Fee Tracker"                             true
+check "llms"         "$BASE_URL/llms.txt"                         "Bitcoin fee intelligence for AI agents" true
+check "x402-page"    "$BASE_URL/x402"                             "premium Bitcoin API calls"               true
+check "docs"         "$BASE_URL/docs"                             "swagger"                                 true
+check "redoc"        "$BASE_URL/redoc"
+check "openapi"      "$BASE_URL/openapi.json"                     '"openapi"'
+check "server-card"  "$BASE_URL/.well-known/mcp/server-card.json" '"serverInfo"'
+check "health"       "$BASE_URL/api/v1/health"                    '"status":"ok"'
+check "fees"         "$BASE_URL/api/v1/fees/recommended"          '"recommendation"'
+check "mempool"      "$BASE_URL/api/v1/mempool"                   '"congestion"'
+check "difficulty"   "$BASE_URL/api/v1/network/difficulty"        '"progress_percent"'
+check "analytics"    "$BASE_URL/api/v1/analytics/public"          '"total_keys"'
+check "x402-demo"    "$BASE_URL/api/v1/x402-demo"                 '"Payment Required"' false 402
+check "x402-info"    "$BASE_URL/api/v1/x402-info"                 '"x402"'
 
-# Summary
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
 if [[ "$QUIET" == "false" ]] || [[ "$FAIL_COUNT" -gt 0 ]]; then
     echo "--- $(date -u '+%Y-%m-%d %H:%M:%S UTC') | $PASS_COUNT/$TOTAL passed"
 fi

--- a/scripts/smoke-test-api.sh
+++ b/scripts/smoke-test-api.sh
@@ -52,7 +52,7 @@ check() {
     [[ "$QUIET" == "false" ]] && echo "PASS  $name"
 }
 
-check "home"         "$BASE_URL/"                                 "Bitcoin Fee Intelligence"                true
+check "home"         "$BASE_URL/"
 check "fees-page"    "$BASE_URL/fees"                             "Fee Tracker"                             true
 check "llms"         "$BASE_URL/llms.txt"                         "Bitcoin fee intelligence for AI agents" true
 check "x402-page"    "$BASE_URL/x402"                             "premium Bitcoin API calls"               true

--- a/scripts/smoke-test-api.sh
+++ b/scripts/smoke-test-api.sh
@@ -52,7 +52,7 @@ check() {
     [[ "$QUIET" == "false" ]] && echo "PASS  $name"
 }
 
-check "home"         "$BASE_URL/"                                 "Satoshi API"                             true
+check "home"         "$BASE_URL/"                                 "Bitcoin Fee Intelligence"                true
 check "fees-page"    "$BASE_URL/fees"                             "Fee Tracker"                             true
 check "llms"         "$BASE_URL/llms.txt"                         "Bitcoin fee intelligence for AI agents" true
 check "x402-page"    "$BASE_URL/x402"                             "premium Bitcoin API calls"               true

--- a/src/bitcoin_api/middleware.py
+++ b/src/bitcoin_api/middleware.py
@@ -132,7 +132,26 @@ def _emit_access_log(client_ip: str, method: str, path: str, status: int,
 # Client classification
 # ---------------------------------------------------------------------------
 
-_AI_AGENT_PATTERNS = ("claude", "openai", "anthropic", "langchain", "autogpt")
+_AI_AGENT_PATTERNS = (
+    "claude",
+    "claudebot",
+    "anthropic",
+    "anthropic-ai",
+    "openai",
+    "chatgpt",
+    "chatgpt-user",
+    "gptbot",
+    "oai-searchbot",
+    "perplexity",
+    "google-extended",
+    "googleother",
+    "gemini",
+    "bingbot",
+    "copilot",
+    "meta-externalagent",
+    "langchain",
+    "autogpt",
+)
 _SDK_PATTERNS = ("python-requests", "httpx", "axios", "node-fetch", "curl")
 _BROWSER_PATTERNS = ("mozilla", "chrome", "safari", "firefox")
 
@@ -151,29 +170,74 @@ def classify_client(user_agent: str) -> str:
     return "unknown"
 
 _DOCS_PATHS = {"/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json", "/admin/dashboard", "/admin/founder", "/visualizer"}
-_NOINDEX_PATHS = {"/docs", "/redoc", "/openapi.json", "/visualizer", "/x402"}
+_NOINDEX_PATHS = {"/docs", "/redoc", "/openapi.json", "/visualizer", "/ai"}
 _NOINDEX_PREFIXES = ("/history/block", "/history/tx", "/history/address")
 
-_PAGEVIEW_LOG_PATHS = {
-    "/", "/docs", "/redoc", "/admin/dashboard", "/admin/founder",
-    "/vs-mempool", "/vs-blockcypher", "/best-bitcoin-api-for-developers",
-    "/bitcoin-api-for-ai-agents", "/self-hosted-bitcoin-api",
-    "/bitcoin-fee-api", "/bitcoin-mempool-api", "/bitcoin-mcp-setup-guide",
-    "/terms", "/privacy", "/disclaimer", "/about", "/pricing", "/mcp-setup", "/guide",
+_PUBLIC_WEB_PATHS = {
+    "/",
+    "/api-docs",
+    "/fee-observatory",
+    "/about",
+    "/ai",
+    "/best-bitcoin-api-for-developers",
+    "/best-time-to-send-bitcoin",
+    "/bitcoin-api-for-ai-agents",
+    "/bitcoin-api-for-trading-bots",
+    "/bitcoin-fee-api",
+    "/bitcoin-fee-estimator",
+    "/bitcoin-mcp-setup-guide",
+    "/bitcoin-mempool-api",
+    "/bitcoin-transaction-fee-calculator",
+    "/disclaimer",
+    "/fees",
+    "/guide",
     "/history",
+    "/how-to-reduce-bitcoin-transaction-fees",
+    "/mcp-setup",
+    "/pricing",
+    "/privacy",
+    "/self-hosted-bitcoin-api",
+    "/terms",
+    "/visualizer",
+    "/vs-blockcypher",
+    "/vs-mempool",
+    "/x402",
 }
 
-_RATE_LIMIT_SKIP = {
-    "/", "/docs", "/redoc", "/openapi.json", "/api/v1/health", "/api/v1/guide", "/healthz",
-    "/api/v1/stream/blocks", "/api/v1/stream/fees",
-    "/robots.txt", "/sitemap.xml", "/favicon.ico",
-    "/vs-mempool", "/vs-blockcypher", "/best-bitcoin-api-for-developers",
-    "/bitcoin-api-for-ai-agents", "/self-hosted-bitcoin-api",
-    "/bitcoin-fee-api", "/bitcoin-mempool-api", "/bitcoin-mcp-setup-guide",
-    "/terms", "/privacy", "/disclaimer", "/about", "/pricing",
-    "/admin/dashboard", "/admin/founder",
-    "/api/v1/ws",
+_DISCOVERY_PATHS = {
+    "/.well-known/mcp/server-card.json",
+    "/docs",
+    "/docs/oauth2-redirect",
+    "/favicon.ico",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/openapi.json",
+    "/redoc",
+    "/robots.txt",
+    "/sitemap.xml",
+}
+
+_PAGEVIEW_LOG_PATHS = _PUBLIC_WEB_PATHS | {
+    "/.well-known/mcp/server-card.json",
+    "/admin/dashboard",
+    "/admin/founder",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/openapi.json",
+    "/robots.txt",
+    "/sitemap.xml",
+}
+
+_RATE_LIMIT_SKIP = _PUBLIC_WEB_PATHS | _DISCOVERY_PATHS | {
+    "/admin/dashboard",
+    "/admin/founder",
     "/api/v1/billing/webhook",
+    "/api/v1/guide",
+    "/api/v1/health",
+    "/api/v1/stream/blocks",
+    "/api/v1/stream/fees",
+    "/api/v1/ws",
+    "/healthz",
 }
 
 

--- a/src/bitcoin_api/middleware.py
+++ b/src/bitcoin_api/middleware.py
@@ -151,6 +151,8 @@ def classify_client(user_agent: str) -> str:
     return "unknown"
 
 _DOCS_PATHS = {"/docs", "/docs/oauth2-redirect", "/redoc", "/openapi.json", "/admin/dashboard", "/admin/founder", "/visualizer"}
+_NOINDEX_PATHS = {"/docs", "/redoc", "/openapi.json", "/visualizer", "/x402"}
+_NOINDEX_PREFIXES = ("/history/block", "/history/tx", "/history/address")
 
 _PAGEVIEW_LOG_PATHS = {
     "/", "/docs", "/redoc", "/admin/dashboard", "/admin/founder",
@@ -261,8 +263,11 @@ def register_middleware(app: FastAPI):
         client_ip = get_client_ip(request)
         bucket = key_info.key_hash or client_ip
 
+        # --- Skip rate limiting for exempt internal keys (e.g. Kalshi bot) ---
+        _is_exempt = key_info.key_hash in settings.exempt_key_set
+
         # --- Skip rate limiting for registration (users must always be able to upgrade) ---
-        _skip_rate_limit = request.url.path == "/api/v1/register"
+        _skip_rate_limit = request.url.path == "/api/v1/register" or _is_exempt
 
         # --- Per-minute rate limit ---
         result = check_rate_limit(bucket, key_info.tier)
@@ -473,29 +478,43 @@ def register_middleware(app: FastAPI):
     @app.middleware("http")
     async def security_headers(request: Request, call_next):
         response = await call_next(request)
+        path = request.url.path
+        nonce = response.headers.get("X-CSP-Nonce")
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
-        if request.url.path not in _DOCS_PATHS:
+        if path not in _DOCS_PATHS:
+            script_src = [
+                "'self'",
+                "'strict-dynamic'",
+                "https://us-assets.i.posthog.com",
+                "https://us.i.posthog.com",
+                "https://static.cloudflareinsights.com",
+            ]
+            if nonce:
+                script_src.append(f"'nonce-{nonce}'")
             response.headers["Content-Security-Policy"] = (
                 "default-src 'self'; "
-                "script-src 'self' 'strict-dynamic' https://us-assets.i.posthog.com https://us.i.posthog.com; "
+                f"script-src {' '.join(script_src)}; "
                 "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
                 "font-src 'self' https://fonts.gstatic.com; "
                 "img-src 'self' data: https://raw.githubusercontent.com; "
-                "connect-src 'self' https://bitcoinsapi.com https://us.i.posthog.com; "
+                "connect-src 'self' https://bitcoinsapi.com https://us.i.posthog.com https://cloudflareinsights.com; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "
                 "form-action 'self'"
             )
+        if "X-CSP-Nonce" in response.headers:
+            del response.headers["X-CSP-Nonce"]
+        if path in _NOINDEX_PATHS or any(path.startswith(prefix) for prefix in _NOINDEX_PREFIXES):
+            response.headers["X-Robots-Tag"] = "noindex, follow"
         if request.url.scheme == "https" or request.headers.get("x-forwarded-proto") == "https":
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
         progress = get_sync_progress()
         if progress is not None and progress < 0.9999:
             response.headers["X-Node-Syncing"] = "true"
 
-        path = request.url.path
         if path.startswith("/api/v1/"):
             response.headers["X-Data-Disclaimer"] = "For informational purposes only. Not financial advice. See /terms"
         if "Cache-Control" not in response.headers:

--- a/src/bitcoin_api/routers/guide.py
+++ b/src/bitcoin_api/routers/guide.py
@@ -118,7 +118,7 @@ def _build_categories() -> list[dict]:
                 _ep("GET", "/api/v1/fees/plan", "Transaction cost planner — estimate costs across urgency tiers (immediate/standard/patient/opportunistic). Supports profiles (simple_send, batch_payout, consolidation), address types, and USD currency."),
                 _ep("GET", "/api/v1/fees/savings", "Fee savings simulation — compare always-send-now vs optimal timing over the last 7 days. Shows savings per tx and monthly projection."),
                 _ep("GET", "/api/v1/fees/3", "Fee estimate for a specific block target"),
-                _ep("GET", "/api/v1/fees/landscape", "Full fee landscape across all targets"),
+                _ep("GET", "/api/v1/fees/landscape", "Full fee landscape across all targets (premium on hosted API: x402 or paid tier)"),
                 _ep("GET", "/api/v1/fees/estimate-tx", "Estimate fee for a specific transaction"),
                 _ep("GET", "/api/v1/fees/history", "Historical fee data"),
                 _ep("GET", "/api/v1/fees/mempool-blocks", "Projected mempool blocks with fee ranges"),
@@ -153,7 +153,7 @@ def _build_categories() -> list[dict]:
                 _ep("GET", "/api/v1/utxo/{txid}/{vout}", "UTXO lookup"),
                 _ep("POST", "/api/v1/decode", "Decode a raw transaction hex", auth=True),
                 _ep("GET", "/api/v1/tx/{txid}/merkle-proof", "Merkle proof for confirmed transaction"),
-                _ep("POST", "/api/v1/broadcast", "Broadcast a signed transaction", auth=True),
+                _ep("POST", "/api/v1/broadcast", "Broadcast a signed transaction (API key or x402 on hosted API)", auth=True),
             ],
         },
         {
@@ -174,12 +174,12 @@ def _build_categories() -> list[dict]:
             "description": "Mining stats, difficulty, hashrate history, and revenue analysis",
             "endpoints": [
                 _ep("GET", "/api/v1/mining", "Mining overview: difficulty, hashrate, retarget"),
-                _ep("GET", "/api/v1/mining/nextblock", "Next block fee prediction"),
-                _ep("GET", "/api/v1/mining/hashrate/history", "Hashrate history over recent blocks"),
-                _ep("GET", "/api/v1/mining/revenue", "Mining revenue breakdown"),
-                _ep("GET", "/api/v1/mining/pools", "Pool identification from coinbase tags"),
+                _ep("GET", "/api/v1/mining/nextblock", "Next block fee prediction (premium on hosted API: x402 or paid tier)"),
+                _ep("GET", "/api/v1/mining/hashrate/history", "Hashrate history over recent blocks", auth=True),
+                _ep("GET", "/api/v1/mining/revenue", "Mining revenue breakdown", auth=True),
+                _ep("GET", "/api/v1/mining/pools", "Pool identification from coinbase tags", auth=True),
                 _ep("GET", "/api/v1/mining/difficulty/history", "Difficulty adjustment history"),
-                _ep("GET", "/api/v1/mining/revenue/history", "Per-block revenue history"),
+                _ep("GET", "/api/v1/mining/revenue/history", "Per-block revenue history", auth=True),
             ],
         },
         {
@@ -211,6 +211,8 @@ def _build_categories() -> list[dict]:
                 _ep("GET", "/api/v1/health", "Quick health check"),
                 _ep("GET", "/api/v1/status", "Detailed node and API status"),
                 _ep("GET", "/api/v1/health/deep", "Deep health check with component status", auth=True),
+                _ep("GET", "/api/v1/x402-info", "x402 payment information and premium endpoint pricing"),
+                _ep("GET", "/api/v1/x402-demo", "Sample 402 challenge flow for x402 client testing"),
             ],
         },
         {
@@ -283,8 +285,8 @@ def _build_categories() -> list[dict]:
             "use_case": "address",
             "description": "Address balance and UTXO lookup",
             "endpoints": [
-                _ep("GET", "/api/v1/address/{addr}", "Address summary"),
-                _ep("GET", "/api/v1/address/{addr}/utxos", "Address UTXOs"),
+                _ep("GET", "/api/v1/address/{addr}", "Address summary", auth=True),
+                _ep("GET", "/api/v1/address/{addr}/utxos", "Address UTXOs", auth=True),
             ],
         })
     if flags.get("exchange_compare", False):
@@ -311,9 +313,9 @@ def _build_categories() -> list[dict]:
             "use_case": "statistics",
             "description": "On-chain statistics and adoption metrics",
             "endpoints": [
-                _ep("GET", "/api/v1/stats/utxo-set", "UTXO set statistics"),
-                _ep("GET", "/api/v1/stats/segwit-adoption", "SegWit adoption metrics"),
-                _ep("GET", "/api/v1/stats/op-returns", "OP_RETURN data analysis"),
+                _ep("GET", "/api/v1/stats/utxo-set", "UTXO set statistics", auth=True),
+                _ep("GET", "/api/v1/stats/segwit-adoption", "SegWit adoption metrics", auth=True),
+                _ep("GET", "/api/v1/stats/op-returns", "OP_RETURN data analysis", auth=True),
             ],
         })
 
@@ -393,6 +395,7 @@ def guide(
         "links": {
             "docs": "/docs",
             "register": "/api/v1/register",
+            "x402": "/x402",
             "terms": "/terms",
             "privacy": "/privacy",
             "github": "https://github.com/Bortlesboat/bitcoin-api",

--- a/src/bitcoin_api/static_routes.py
+++ b/src/bitcoin_api/static_routes.py
@@ -1,5 +1,6 @@
 """Static file routes: landing page, robots.txt, sitemap, decision pages, admin dashboard."""
 
+import re
 import secrets
 from pathlib import Path
 
@@ -25,12 +26,19 @@ def _render_html(path: Path) -> HTMLResponse | None:
     html = path.read_text(encoding="utf-8")
     ph_key = settings.posthog_api_key.get_secret_value() if settings.posthog_api_key else ""
     html = html.replace("__POSTHOG_API_KEY__", ph_key)
+    if '/static/js/site-helpers.js' not in html:
+        helper_tag = '<script src="/static/js/site-helpers.js"></script>'
+        html = re.sub(r"</body>", helper_tag + "\n</body>", html, count=1, flags=re.IGNORECASE)
+    nonce = secrets.token_urlsafe(16)
+    html = re.sub(r"<script(?![^>]*\bnonce=)", f'<script nonce="{nonce}"', html, flags=re.IGNORECASE)
 
     # Keep public navigation safe when the History Explorer is disabled.
     if not settings.enable_history_explorer:
         html = html.replace('href="/history"', 'href="/guide"')
 
-    return HTMLResponse(html)
+    response = HTMLResponse(html)
+    response.headers["X-CSP-Nonce"] = nonce
+    return response
 
 
 def _serve_404():
@@ -50,16 +58,18 @@ def register_static_routes(app: FastAPI):
     if _js_dir.is_dir():
         app.mount("/static/js", StaticFiles(directory=str(_js_dir)), name="static-js")
 
-    @app.get("/", include_in_schema=False)
+    _PUBLIC_METHODS = ["GET", "HEAD"]
+
+    @app.api_route("/", methods=_PUBLIC_METHODS, include_in_schema=False)
     def root():
         return _render_html(_LANDING_PAGE) or _serve_404()
 
-    @app.get("/api-docs", include_in_schema=False)
+    @app.api_route("/api-docs", methods=_PUBLIC_METHODS, include_in_schema=False)
     def api_docs_redirect():
         """Avoid maintaining a second docs surface; send users to live Swagger docs."""
-        return RedirectResponse(url="/docs", status_code=307)
+        return RedirectResponse(url="/docs", status_code=308)
 
-    @app.get("/.well-known/mcp/server-card.json", include_in_schema=False)
+    @app.api_route("/.well-known/mcp/server-card.json", methods=_PUBLIC_METHODS, include_in_schema=False)
     def mcp_server_card():
         """MCP server card for Smithery discovery."""
         p = _STATIC_DIR / ".well-known" / "mcp" / "server-card.json"
@@ -71,35 +81,35 @@ def register_static_routes(app: FastAPI):
             )
         return Response(status_code=404)
 
-    @app.get("/favicon.ico", include_in_schema=False)
+    @app.api_route("/favicon.ico", methods=_PUBLIC_METHODS, include_in_schema=False)
     def favicon():
         p = _STATIC_DIR / "favicon.ico"
         if p.exists():
             return Response(p.read_bytes(), media_type="image/x-icon")
         return Response(status_code=204)
 
-    @app.get("/robots.txt", include_in_schema=False)
+    @app.api_route("/robots.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def robots_txt():
         p = _STATIC_DIR / "robots.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return Response("User-agent: *\nAllow: /\n", media_type="text/plain")
 
-    @app.get("/llms.txt", include_in_schema=False)
+    @app.api_route("/llms.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def llms_txt():
         p = _STATIC_DIR / "llms.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return _serve_404()
 
-    @app.get("/llms-full.txt", include_in_schema=False)
+    @app.api_route("/llms-full.txt", methods=_PUBLIC_METHODS, include_in_schema=False)
     def llms_full_txt():
         p = _STATIC_DIR / "llms-full.txt"
         if p.exists():
             return Response(p.read_text(encoding="utf-8"), media_type="text/plain")
         return _serve_404()
 
-    @app.get("/sitemap.xml", include_in_schema=False)
+    @app.api_route("/sitemap.xml", methods=_PUBLIC_METHODS, include_in_schema=False)
     def sitemap_xml():
         p = _STATIC_DIR / "sitemap.xml"
         if p.exists():
@@ -108,7 +118,7 @@ def register_static_routes(app: FastAPI):
 
     _IMAGE_TYPES = {".png": "image/png", ".jpg": "image/jpeg", ".svg": "image/svg+xml", ".webp": "image/webp"}
 
-    @app.get("/{filename}.{ext}", include_in_schema=False)
+    @app.api_route("/{filename}.{ext}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def static_asset(filename: str, ext: str):
         """Serve static assets (images + IndexNow verification key) from the static directory."""
         # Prevent path traversal
@@ -180,7 +190,7 @@ def register_static_routes(app: FastAPI):
         """Process-alive check (no RPC call). Use for container healthchecks."""
         return {"status": "ok"}
 
-    @app.get("/history", include_in_schema=False)
+    @app.api_route("/history", methods=_PUBLIC_METHODS, include_in_schema=False)
     def history_index():
         """Serve the History Explorer index page (feature-flag gated)."""
         from .config import settings
@@ -189,7 +199,7 @@ def register_static_routes(app: FastAPI):
         p = _HISTORY_DIR / "index.html"
         return _render_html(p) or _serve_404()
 
-    @app.get("/history/{page}", include_in_schema=False)
+    @app.api_route("/history/{page}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def history_page(page: str):
         """Serve History Explorer sub-pages and static assets."""
         from .config import settings
@@ -210,9 +220,11 @@ def register_static_routes(app: FastAPI):
             return Response(resolved.read_text(encoding="utf-8"), media_type=media_types[resolved.suffix])
         return _serve_404()
 
-    @app.get("/{page}", include_in_schema=False)
+    @app.api_route("/{page}", methods=_PUBLIC_METHODS, include_in_schema=False)
     def static_page(page: str):
         """Serve decision/comparison pages and IndexNow key from static directory."""
+        if page == "fee-observatory":
+            return RedirectResponse(url="/fees", status_code=308)
         allowed = {
             "vs-mempool", "vs-blockcypher", "best-bitcoin-api-for-developers",
             "bitcoin-api-for-ai-agents", "self-hosted-bitcoin-api",
@@ -221,7 +233,7 @@ def register_static_routes(app: FastAPI):
             "bitcoin-fee-estimator", "bitcoin-api-for-trading-bots",
             "how-to-reduce-bitcoin-transaction-fees",
             "terms", "privacy", "disclaimer", "visualizer", "pricing", "about", "guide",
-            "mcp-setup", "ai", "fees", "fee-observatory", "x402",
+            "mcp-setup", "ai", "fees", "x402",
         }
         if page in allowed:
             p = _STATIC_DIR / f"{page}.html"

--- a/static/.well-known/mcp/server-card.json
+++ b/static/.well-known/mcp/server-card.json
@@ -2,7 +2,7 @@
   "serverInfo": {
     "name": "bitcoin",
     "version": "0.5.0",
-    "description": "MCP server for Bitcoin — 49 tools for AI agents to save money on fees. Zero config, works out of the box."
+    "description": "Bitcoin fee-intelligence MCP server for AI agents - 49 tools for send-or-wait decisions, mempool analysis, and premium x402 calls. Zero config, works out of the box."
   },
   "capabilities": {
     "tools": { "listChanged": false },

--- a/static/bitcoin-api-for-ai-agents.html
+++ b/static/bitcoin-api-for-ai-agents.html
@@ -17,9 +17,6 @@
 <meta name="twitter:title" content="Bitcoin Fee Intelligence for AI Agents - MCP-Native">
 <meta name="twitter:description" content="Give Claude or any AI agent live Bitcoin fee intelligence via MCP. Satoshi API + bitcoin-mcp lets agents decide when to send, what fee to use, and how much a transaction will cost.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {
     --bg: #0d1117;
@@ -32,10 +29,10 @@
     --green: #3fb950;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
   a { color: var(--blue); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+  code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
   pre { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; overflow-x: auto; font-size: 0.85em; line-height: 1.7; }
   pre code { background: none; padding: 0; }
 
@@ -409,6 +406,7 @@
       <a href="https://github.com/Bortlesboat/bitcoin-mcp" class="btn-secondary" target="_blank" rel="noopener noreferrer">Get bitcoin-mcp</a>
     </div>
     <p style="color: var(--muted); margin-top: 16px;">Testing agent workflows with this? <a href="https://github.com/Bortlesboat/bitcoin-api/issues" target="_blank" rel="noopener noreferrer">Open an issue</a> or join the <a href="https://discord.gg/EB6Jd66EsF" target="_blank" rel="noopener noreferrer">Discord community</a> with the prompt, workflow, or edge case you want supported.</p>
+    <p style="color: var(--muted); margin-top: 10px;">Need keyless premium calls for agent-only workflows? See <a href="/x402">how Satoshi API uses x402</a> for pay-per-call access.</p>
   </div>
 </section>
 
@@ -419,12 +417,14 @@
       <a href="https://github.com/Bortlesboat/bitcoin-api" target="_blank" rel="noopener noreferrer">GitHub</a> &middot;
       <a href="https://pypi.org/project/satoshi-api/" target="_blank" rel="noopener noreferrer">PyPI</a> &middot;
       <a href="/docs">API Docs</a> &middot;
+      <a href="/x402">x402</a> &middot;
       <a href="https://github.com/Bortlesboat/bitcoin-mcp" target="_blank" rel="noopener noreferrer">bitcoin-mcp</a>
     </p>
     <p style="margin-top: 8px;">
       <a href="/">Home</a> &middot;
       <a href="/best-bitcoin-api-for-developers">Best Bitcoin API for Developers</a> &middot;
       <a href="/self-hosted-bitcoin-api">Self-Hosted Bitcoin API</a> &middot;
+      <a href="/x402">x402 for agents</a> &middot;
       <a href="/vs-mempool">vs Mempool.space</a> &middot;
       <a href="/vs-blockcypher">vs BlockCypher</a>
     </p>

--- a/static/fees.html
+++ b/static/fees.html
@@ -17,9 +17,6 @@
 <meta name="twitter:title" content="Bitcoin Fee Tracker — Live Rates & Send-or-Wait Verdicts">
 <meta name="twitter:description" content="Real-time Bitcoin fee tracker with send-or-wait verdicts. See current fees, congestion level, and how much you can save by waiting.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
 <script type="application/ld+json">
 {"@context":"https://schema.org","@graph":[{"@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://bitcoinsapi.com/"},{"@type":"ListItem","position":2,"name":"Fee Tracker","item":"https://bitcoinsapi.com/fees"}]},{"@type":"WebApplication","@id":"https://bitcoinsapi.com/fees/#app","name":"Bitcoin Fee Tracker","description":"Real-time Bitcoin fee tracker with send-or-wait verdicts, congestion monitoring, and savings calculator.","url":"https://bitcoinsapi.com/fees","applicationCategory":"FinanceApplication","operatingSystem":"Web","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"publisher":{"@id":"https://bitcoinsapi.com/#organization"}}]}
@@ -78,10 +75,10 @@
     --green: #3fb950;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
   a { color: var(--blue); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+  code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
 
   /* Sync Warning Banner */
   .sync-banner { display: none; background: #D2992233; border-bottom: 1px solid #D29922; padding: 10px 24px; text-align: center; font-size: 0.9em; color: #D29922; position: sticky; top: 53px; z-index: 9; }
@@ -118,7 +115,7 @@
 
   /* Code block */
   .code-block { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; margin: 20px 0; overflow-x: auto; }
-  .code-block pre { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85em; color: var(--text); line-height: 1.6; white-space: pre; }
+  .code-block pre { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; font-size: 0.85em; color: var(--text); line-height: 1.6; white-space: pre; }
   .code-block .comment { color: var(--muted); }
   .code-block .cmd { color: var(--green); }
 
@@ -257,7 +254,7 @@
     font-size: 1.8em;
     font-weight: 700;
     color: var(--text);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace;
   }
   .stat-label {
     font-size: 0.8em;
@@ -290,7 +287,7 @@
   .savings-card .fee-amount {
     font-size: 1.4em;
     font-weight: 700;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace;
   }
   .savings-card .fee-usd {
     font-size: 0.9em;
@@ -342,7 +339,7 @@
 
 <nav style="background:#1a1a2e;padding:12px 24px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:100;flex-wrap:wrap;">
   <a href="/" style="color:#f7931a;font-weight:700;font-size:1.2rem;text-decoration:none;">Satoshi API</a>
-  <button class="nav-toggle" onclick="document.querySelector('.nav-links').classList.toggle('open')" aria-label="Menu" style="display:none;background:none;border:1px solid #30363d;border-radius:4px;color:#8b949e;padding:6px 10px;cursor:pointer;font-size:1.2em;line-height:1;">&#9776;</button>
+  <button class="nav-toggle" data-nav-toggle=".nav-links" aria-label="Menu" style="display:none;background:none;border:1px solid #30363d;border-radius:4px;color:#8b949e;padding:6px 10px;cursor:pointer;font-size:1.2em;line-height:1;">&#9776;</button>
   <div class="nav-links" style="display:flex;gap:20px;align-items:center;">
     <a href="/" style="color:#ccc;text-decoration:none;">Home</a>
     <a href="/docs" style="color:#ccc;text-decoration:none;">Docs</a>
@@ -801,7 +798,19 @@ print(data["data"]["recommendation"], data["data"]["reasoning"])</pre>
     setText('refresh-counter', ago);
   }
 
+  function bindNavToggle() {
+    var toggle = document.querySelector('[data-nav-toggle]');
+    if (!toggle) return;
+    var targetSelector = toggle.getAttribute('data-nav-toggle');
+    var target = targetSelector ? document.querySelector(targetSelector) : null;
+    if (!target) return;
+    toggle.addEventListener('click', function() {
+      target.classList.toggle('open');
+    });
+  }
+
   /* ---- Init ---- */
+  bindNavToggle();
   refreshData();
   setInterval(refreshData, 30000);
   setInterval(updateCounter, 1000);

--- a/static/history/index.html
+++ b/static/history/index.html
@@ -5,6 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bitcoin History Explorer — Satoshi API</title>
 <meta name="description" content="Explore Bitcoin's history from the genesis block to $100K. Interactive timeline with on-chain data, protocol concepts, and MCP tools.">
+<link rel="canonical" href="https://bitcoinsapi.com/history">
+<meta property="og:title" content="Bitcoin History Explorer â€” Satoshi API">
+<meta property="og:description" content="Explore Bitcoin's history from the genesis block to $100K with linked on-chain events, protocol context, and MCP tools.">
+<meta property="og:url" content="https://bitcoinsapi.com/history">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://bitcoinsapi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@BTCOrangeCoin">
+<meta name="twitter:title" content="Bitcoin History Explorer â€” Satoshi API">
+<meta name="twitter:description" content="Explore Bitcoin's history from the genesis block to $100K with linked on-chain events, protocol context, and MCP tools.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/static/index.html
+++ b/static/index.html
@@ -21,9 +21,6 @@
 <meta name="twitter:title" content="Satoshi API - Bitcoin Fee Intelligence for Apps and AI Agents">
 <meta name="twitter:description" content="Know when to send Bitcoin and when to wait. Live fee recommendations, mempool context, and transaction cost estimates for apps and AI agents.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   :root {
     --bg: #000000;
@@ -53,10 +50,10 @@
     --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
   a { color: var(--accent); text-decoration: none; transition: color 0.2s var(--ease-out); }
   a:hover { color: var(--accent-hover); }
-  code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 8px; border-radius: 6px; font-size: 0.875em; }
+  code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 8px; border-radius: 6px; font-size: 0.875em; }
   pre { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 24px; overflow-x: auto; font-size: 0.875em; line-height: 1.7; }
   pre code { background: none; padding: 0; font-size: 1em; }
 
@@ -173,7 +170,7 @@
 
   /* Footer */
   footer { border-top: 1px solid var(--border); padding: 64px 24px; text-align: center; color: var(--muted); font-size: 0.85em; }
-  footer a { color: var(--dim); transition: color 0.2s var(--ease-out); }
+  footer a { color: var(--muted); transition: color 0.2s var(--ease-out); }
   footer a:hover { color: var(--text); }
 
   /* Subtle grain texture — low z-index so it never blocks content */
@@ -461,7 +458,7 @@
 
 <nav>
   <div class="logo"><img src="/logo-128.png" alt="Satoshi API" width="24" height="24" style="height:24px;vertical-align:middle;margin-right:8px;">SATOSHI API</div>
-  <button class="nav-toggle" onclick="document.querySelector('.links').classList.toggle('open')" aria-label="Menu">&#9776;</button>
+    <button class="nav-toggle" data-nav-toggle=".links" aria-label="Menu">&#9776;</button>
   <div class="links">
     <a href="#why-satoshi">Why Satoshi API</a>
     <a href="/bitcoin-fee-api">Fee API</a>
@@ -486,8 +483,8 @@
     <h1>Know the cheapest time to <span>send Bitcoin.</span></h1>
     <p class="subtitle">Satoshi API gives apps and AI agents live fee recommendations, mempool context, and transaction cost estimates so they can answer the only question that matters: send now or wait and save money.</p>
     <div class="cta">
-      <a href="/bitcoin-fee-api" class="btn-primary" onclick="posthog.capture('cta_click', {location:'hero',target:'fee_api'})">Check Live Fees</a>
-      <a href="#get-api-key" class="btn-secondary" onclick="posthog.capture('cta_click', {location:'hero',target:'get_api_key'})">Get Free API Key</a>
+      <a href="/bitcoin-fee-api" class="btn-primary" data-track-event="cta_click" data-track-location="hero" data-track-target="fee_api">Check Live Fees</a>
+      <a href="#get-api-key" class="btn-secondary" data-track-event="cta_click" data-track-location="hero" data-track-target="get_api_key">Get Free API Key</a>
     </div>
     <div class="hero-code">
 <pre><code><span style="color: var(--muted)">$ </span>pip install bitcoin-mcp</code></pre>
@@ -532,28 +529,28 @@
     <p class="section-subtitle">Copy any prompt below into Claude Desktop with <a href="https://github.com/Bortlesboat/bitcoin-mcp" target="_blank" rel="noopener noreferrer">bitcoin-mcp</a> installed. These are the highest-value workflows for first-time users.</p>
     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 48px;">
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="What's the current fee environment? Should I send a transaction now or wait for lower fees? How much would I save by waiting?">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="What's the current fee environment? Should I send a transaction now or wait for lower fees? How much would I save by waiting?">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Save Money</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Should I send Bitcoin right now?"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Get a send/wait recommendation with specific sat/vB rates and estimated savings if you wait.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Track this transaction and tell me when it's safe to consider confirmed: [paste your txid here]">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Track this transaction and tell me when it's safe to consider confirmed: [paste your txid here]">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Save Time</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Track this payment"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Paste a txid. Get confirmation count, fee rate, RBF status, and whether it'll make the next block.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Analyze the current mempool. How congested is it? What's the fee distribution? How many transactions are waiting?">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Analyze the current mempool. How congested is it? What's the fee distribution? How many transactions are waiting?">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Understand</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"What's happening in the mempool?"</p>
         <p style="color: var(--muted); font-size: 0.85em;">Congestion level, fee buckets, next-block minimum fee, and total pending transactions.</p>
       </div>
 
-      <div class="feature" style="cursor: pointer; position: relative;" onclick="copyPrompt(this)" data-prompt="Compare fee rates for different urgency levels. How much more does next-block confirmation cost vs. waiting an hour? Show me the exact cost in sats for a typical transaction.">
+      <div class="feature" style="cursor: pointer; position: relative;" role="button" tabindex="0" data-prompt="Compare fee rates for different urgency levels. How much more does next-block confirmation cost vs. waiting an hour? Show me the exact cost in sats for a typical transaction.">
         <div style="position: absolute; top: 12px; right: 12px; font-size: 0.7em; color: var(--muted); opacity: 0.6;">click to copy</div>
         <h3 style="color: var(--accent); font-size: 0.85em; font-weight: 600; margin-bottom: 8px;">Compare</h3>
         <p style="color: var(--text); font-size: 1em; font-weight: 600; margin-bottom: 8px;">"Compare urgency levels"</p>
@@ -562,7 +559,7 @@
 
     </div>
     <p style="text-align: center; margin-top: 32px;">
-      <a href="/bitcoin-api-for-ai-agents" style="font-weight: 600;" onclick="posthog.capture('cta_click', {location:'try_these', target:'ai_agents_page'})">See the AI agent setup guide &rarr;</a>
+      <a href="/bitcoin-api-for-ai-agents" style="font-weight: 600;" data-track-event="cta_click" data-track-location="try_these" data-track-target="ai_agents_page">See the AI agent setup guide &rarr;</a>
     </p>
   </div>
 </section>
@@ -673,7 +670,7 @@
 }</code></pre>
       </div>
     </div>
-    <p style="text-align: center; margin-top: 32px;"><a href="/docs" style="font-weight: 600;" onclick="posthog.capture('docs_click', {location:'see_it_work'})">Explore all endpoints &rarr;</a></p>
+    <p style="text-align: center; margin-top: 32px;"><a href="/docs" style="font-weight: 600;" data-track-event="docs_click" data-track-location="see_it_work">Explore all endpoints &rarr;</a></p>
   </div>
 </section>
 
@@ -805,7 +802,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
     <h3 id="get-api-key" style="margin-top: 48px; margin-bottom: 12px;">Option 2: Get a free API key (10x higher limits)</h3>
     <p style="color: var(--muted); margin-bottom: 16px;">Unlock 10,000 requests/day and POST access. Takes 5 seconds:</p>
     <div style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 28px; max-width: 480px;">
-      <form id="register-form" onsubmit="return handleRegister(event)">
+<form id="register-form">
         <div style="display: flex; gap: 8px; margin-bottom: 8px;">
           <input type="email" id="reg-email" placeholder="you@example.com" required
             style="flex: 1; padding: 12px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-visible); background: var(--surface-elevated); color: var(--text); font-family: 'Plus Jakarta Sans', sans-serif; font-size: 0.95em; outline: none; transition: border-color 0.2s;"
@@ -852,7 +849,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>All GET endpoints + POST with key</li>
           <li>Always up-to-date</li>
         </ul>
-        <a href="#quickstart" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" onclick="posthog.capture('pricing_viewed', {tier:'hosted_free'})">Get Started</a>
+        <a href="#quickstart" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="hosted_free">Get Started</a>
       </div>
       <div class="price-card">
         <h3>Self-Hosted</h3>
@@ -864,7 +861,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>Full source code (Apache-2.0)</li>
           <li>Docker + pip install</li>
         </ul>
-        <a href="https://github.com/Bortlesboat/bitcoin-api" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" target="_blank" rel="noopener noreferrer" onclick="posthog.capture('pricing_viewed', {tier:'self_hosted'})">View on GitHub</a>
+        <a href="https://github.com/Bortlesboat/bitcoin-api" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" target="_blank" rel="noopener noreferrer" data-track-event="pricing_viewed" data-track-tier="self_hosted">View on GitHub</a>
       </div>
       <div class="price-card">
         <h3>Pay-per-call <span style="font-size: 0.7em; background: var(--accent); color: var(--bg); padding: 2px 8px; border-radius: 4px; vertical-align: middle;">x402</span></h3>
@@ -875,9 +872,9 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>AI analysis, tx broadcast</li>
           <li>Built for AI agents</li>
           <li>Standard HTTP 402 protocol</li>
-          <li>100+ endpoints remain free</li>
+          <li>109 endpoints remain free</li>
         </ul>
-        <a href="/api/v1/x402-demo" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" onclick="posthog.capture('pricing_viewed', {tier:'x402'})">Try the Demo</a>
+        <a href="/api/v1/x402-demo" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="x402">Try the Demo</a>
       </div>
     </div>
     <p style="color: var(--muted); text-align: center; margin-top: 24px; font-size: 0.9em;">Need higher hosted limits or a specific integration path? Contact <a href="mailto:api@bitcoinsapi.com">api@bitcoinsapi.com</a>.</p>
@@ -937,9 +934,9 @@ curl -H 'X-PAYMENT: demo' https://bitcoinsapi.com/api/v1/x402-demo</code></pre>
     <h2>Get a better Bitcoin fee decision in 60 seconds.</h2>
     <p>No signup, no install, no node. Check live fees now or plug the API into Claude via MCP.</p>
     <div class="cta" style="display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center;">
-      <a href="#quickstart" class="btn-primary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('cta_click', {location:'bottom',target:'quickstart'})">Get Started Free</a>
-      <a href="#get-api-key" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('cta_click', {location:'bottom',target:'get_api_key'})">Get Free API Key</a>
-      <a href="/docs" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" onclick="posthog.capture('docs_click', {location:'bottom'})">Interactive Docs</a>
+      <a href="#quickstart" class="btn-primary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="cta_click" data-track-location="bottom" data-track-target="quickstart">Get Started Free</a>
+      <a href="#get-api-key" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="cta_click" data-track-location="bottom" data-track-target="get_api_key">Get Free API Key</a>
+      <a href="/docs" class="btn-secondary" style="padding: 16px 32px; border-radius: var(--radius-pill); font-weight: 600;" data-track-event="docs_click" data-track-location="bottom">Interactive Docs</a>
     </div>
     <p style="color: var(--muted); margin-top: 16px; font-size: 0.95em;">Want to be an early tester? <a href="https://github.com/Bortlesboat/bitcoin-api/issues" target="_blank" rel="noopener noreferrer">Open a GitHub issue</a> or join the <a href="https://discord.gg/EB6Jd66EsF" target="_blank" rel="noopener noreferrer">Discord community</a> and tell me what is missing, confusing, or broken.</p>
   </div>
@@ -1053,6 +1050,18 @@ function readStoredAttribution(key) {
 
 storeAttribution();
 
+function track(eventName, props) {
+  if (window.posthog && typeof window.posthog.capture === 'function') {
+    posthog.capture(eventName, props || {});
+  }
+}
+
+function identifyUser(id) {
+  if (window.posthog && typeof window.posthog.identify === 'function') {
+    posthog.identify(id);
+  }
+}
+
 /* API Key Registration */
 function handleRegister(e) {
   e.preventDefault();
@@ -1099,7 +1108,7 @@ function handleRegister(e) {
     if (firstTouch.utm_content) body.first_utm_content = firstTouch.utm_content;
   }
 
-  posthog.capture('registration_submitted', {
+  track('registration_submitted', {
     location: 'register_form',
     utm_source: body.utm_source || '',
     utm_medium: body.utm_medium || '',
@@ -1125,11 +1134,11 @@ function handleRegister(e) {
       if (window.crypto && window.crypto.subtle) {
         crypto.subtle.digest('SHA-256', new TextEncoder().encode(hashedEmail)).then(function(buf) {
           var hash = Array.from(new Uint8Array(buf)).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
-          posthog.identify(hash);
-          posthog.capture('registration_success', { tier: 'free' });
+          identifyUser(hash);
+          track('registration_success', { tier: 'free' });
         });
       } else {
-        posthog.capture('registration_success', { tier: 'free' });
+        track('registration_success', { tier: 'free' });
       }
       result.textContent = '';
       var wrapper = document.createElement('div');
@@ -1159,7 +1168,7 @@ function handleRegister(e) {
       result.appendChild(wrapper);
     } else {
       var msg = (res.data.error && res.data.error.detail) || res.data.detail || 'Registration failed. Try again.';
-      posthog.capture('registration_failed', { reason: msg });
+      track('registration_failed', { reason: msg });
       result.textContent = '';
       var errDiv = document.createElement('div');
       errDiv.style.cssText = 'color: #f85149; font-size: 0.9em;';
@@ -1171,7 +1180,7 @@ function handleRegister(e) {
     btn.disabled = false;
     btn.textContent = 'Get Key';
     result.style.display = 'block';
-    posthog.capture('registration_failed', { reason: 'network_error' });
+    track('registration_failed', { reason: 'network_error' });
     result.textContent = '';
     var netErr = document.createElement('div');
     netErr.style.cssText = 'color: #f85149; font-size: 0.9em;';
@@ -1226,10 +1235,60 @@ function copyPrompt(el) {
           hint.style.opacity = '0.6';
         }, 2000);
       }
-      posthog.capture('prompt_copied', { prompt: prompt.substring(0, 50) });
+      track('prompt_copied', { prompt: prompt.substring(0, 50) });
     });
   }
 }
+
+function bindNavToggle() {
+  var toggle = document.querySelector('[data-nav-toggle]');
+  if (!toggle) return;
+  var targetSelector = toggle.getAttribute('data-nav-toggle');
+  var target = targetSelector ? document.querySelector(targetSelector) : null;
+  if (!target) return;
+  toggle.addEventListener('click', function() {
+    target.classList.toggle('open');
+  });
+}
+
+function bindTrackedClicks() {
+  var tracked = document.querySelectorAll('[data-track-event]');
+  tracked.forEach(function(el) {
+    el.addEventListener('click', function() {
+      var props = {};
+      if (el.dataset.trackLocation) props.location = el.dataset.trackLocation;
+      if (el.dataset.trackTarget) props.target = el.dataset.trackTarget;
+      if (el.dataset.trackTier) props.tier = el.dataset.trackTier;
+      track(el.dataset.trackEvent, props);
+    });
+  });
+}
+
+function bindPromptCards() {
+  var promptCards = document.querySelectorAll('[data-prompt]');
+  promptCards.forEach(function(card) {
+    card.addEventListener('click', function() {
+      copyPrompt(card);
+    });
+    card.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        copyPrompt(card);
+      }
+    });
+  });
+}
+
+function bindRegistrationForm() {
+  var form = document.getElementById('register-form');
+  if (!form) return;
+  form.addEventListener('submit', handleRegister);
+}
+
+bindNavToggle();
+bindTrackedClicks();
+bindPromptCards();
+bindRegistrationForm();
 
 /* Scroll reveal with IntersectionObserver */
 (function() {

--- a/static/index.html
+++ b/static/index.html
@@ -874,7 +874,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
           <li>Standard HTTP 402 protocol</li>
           <li>109 endpoints remain free</li>
         </ul>
-        <a href="/api/v1/x402-demo" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="x402">Try the Demo</a>
+        <a href="/x402" class="btn-primary" style="display: block; padding: 12px; border-radius: var(--radius-sm); margin-top: 20px;" data-track-event="pricing_viewed" data-track-tier="x402">Learn x402</a>
       </div>
     </div>
     <p style="color: var(--muted); text-align: center; margin-top: 24px; font-size: 0.9em;">Need higher hosted limits or a specific integration path? Contact <a href="mailto:api@bitcoinsapi.com">api@bitcoinsapi.com</a>.</p>
@@ -895,7 +895,7 @@ curl https://bitcoinsapi.com/api/v1/mining</code></pre>
 curl https://bitcoinsapi.com/api/v1/x402-demo
 # Step 2: Complete the flow
 curl -H 'X-PAYMENT: demo' https://bitcoinsapi.com/api/v1/x402-demo</code></pre>
-      <p style="color: var(--muted); margin-top: 12px; font-size: 0.85em;">Payments settle on <a href="https://base.org" target="_blank" rel="noopener noreferrer">Base</a> (Coinbase L2). Compatible with any x402 client including <a href="https://github.com/coinbase/x402" target="_blank" rel="noopener noreferrer">the official SDK</a>.</p>
+      <p style="color: var(--muted); margin-top: 12px; font-size: 0.85em;">Payments settle on <a href="https://base.org" target="_blank" rel="noopener noreferrer">Base</a> (Coinbase L2). Compatible with any x402 client including <a href="https://github.com/coinbase/x402" target="_blank" rel="noopener noreferrer">the official SDK</a>. See the full guide and live activity at <a href="/x402">/x402</a>.</p>
     </div>
   </div>
 </section>
@@ -951,6 +951,7 @@ curl -H 'X-PAYMENT: demo' https://bitcoinsapi.com/api/v1/x402-demo</code></pre>
       <a href="https://github.com/Bortlesboat/bitcoin-api" target="_blank" rel="noopener noreferrer">GitHub</a> &middot;
       <a href="https://pypi.org/project/satoshi-api/" target="_blank" rel="noopener noreferrer">PyPI</a> &middot;
       <a href="/docs">API Docs</a> &middot;
+      <a href="/x402">x402</a> &middot;
       <a href="https://stats.uptimerobot.com/satoshi-api" target="_blank" rel="noopener noreferrer">Status</a> &middot;
       <a href="https://github.com/Bortlesboat/bitcoin-mcp" target="_blank" rel="noopener noreferrer">MCP Server</a> &middot;
       <a href="https://discord.gg/EB6Jd66EsF" target="_blank" rel="noopener noreferrer">Discord Community</a> &middot;

--- a/static/js/site-helpers.js
+++ b/static/js/site-helpers.js
@@ -1,0 +1,368 @@
+(function () {
+  function splitTopLevel(source) {
+    var tokens = [];
+    var current = "";
+    var quote = "";
+    var escape = false;
+
+    for (var i = 0; i < source.length; i += 1) {
+      var ch = source[i];
+
+      if (escape) {
+        current += ch;
+        escape = false;
+        continue;
+      }
+
+      if (quote) {
+        current += ch;
+        if (ch === "\\") {
+          escape = true;
+        } else if (ch === quote) {
+          quote = "";
+        }
+        continue;
+      }
+
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+
+      if (ch === "{" || ch === "}" || ch === "[" || ch === "]") {
+        return null;
+      }
+
+      if (ch === ",") {
+        tokens.push(current.trim());
+        current = "";
+        continue;
+      }
+
+      current += ch;
+    }
+
+    if (quote) {
+      return null;
+    }
+
+    if (current.trim() || source.trim() === "") {
+      tokens.push(current.trim());
+    }
+
+    return tokens.filter(function (token) {
+      return token.length > 0;
+    });
+  }
+
+  function unquote(token) {
+    if (token.length < 2) {
+      return token;
+    }
+
+    var quote = token[0];
+    var value = token.slice(1, -1);
+    if (quote === "'") {
+      return value.replace(/\\\\/g, "\\").replace(/\\'/g, "'").replace(/\\"/g, '"');
+    }
+
+    try {
+      return JSON.parse(token);
+    } catch (error) {
+      return value.replace(/\\\\/g, "\\").replace(/\\"/g, '"').replace(/\\'/g, "'");
+    }
+  }
+
+  function parseSimpleArgs(source) {
+    if (!source.trim()) {
+      return [];
+    }
+
+    var rawTokens = splitTopLevel(source);
+    if (!rawTokens) {
+      return null;
+    }
+
+    var tokens = [];
+    for (var i = 0; i < rawTokens.length; i += 1) {
+      var token = rawTokens[i];
+      if (!token) {
+        continue;
+      }
+      if (token === "this") {
+        tokens.push({ type: "self" });
+        continue;
+      }
+      if (token === "event") {
+        tokens.push({ type: "event" });
+        continue;
+      }
+      if (/^-?\d+$/.test(token)) {
+        tokens.push({ type: "number", value: Number(token) });
+        continue;
+      }
+      if (
+        (token[0] === "'" && token[token.length - 1] === "'") ||
+        (token[0] === '"' && token[token.length - 1] === '"')
+      ) {
+        tokens.push({ type: "string", value: unquote(token) });
+        continue;
+      }
+      return null;
+    }
+
+    return tokens;
+  }
+
+  function parseObjectLiteral(source) {
+    var pairs = splitTopLevel(source);
+    if (!pairs) {
+      return null;
+    }
+
+    var obj = {};
+    for (var i = 0; i < pairs.length; i += 1) {
+      var pair = pairs[i];
+      var index = pair.indexOf(":");
+      if (index === -1) {
+        return null;
+      }
+
+      var key = pair.slice(0, index).trim().replace(/^['"]|['"]$/g, "");
+      var valueToken = pair.slice(index + 1).trim();
+      if (!key) {
+        return null;
+      }
+
+      if (/^-?\d+$/.test(valueToken)) {
+        obj[key] = Number(valueToken);
+        continue;
+      }
+
+      if (
+        (valueToken[0] === "'" && valueToken[valueToken.length - 1] === "'") ||
+        (valueToken[0] === '"' && valueToken[valueToken.length - 1] === '"')
+      ) {
+        obj[key] = unquote(valueToken);
+        continue;
+      }
+
+      return null;
+    }
+
+    return obj;
+  }
+
+  function parseInvocation(rawCode) {
+    if (!rawCode) {
+      return null;
+    }
+
+    var code = rawCode.trim();
+    var preventDefault = false;
+
+    code = code.replace(/;?\s*return\s+false;?\s*$/i, function () {
+      preventDefault = true;
+      return "";
+    }).trim();
+
+    code = code.replace(/^return\s+/i, "");
+
+    var navMatch = code.match(
+      /^document\.querySelector\((['"])(.*?)\1\)\.classList\.toggle\((['"])(.*?)\3\);?$/i
+    );
+    if (navMatch) {
+      return {
+        type: "nav-toggle",
+        selector: navMatch[2],
+        className: navMatch[4],
+        preventDefault: preventDefault,
+      };
+    }
+
+    var posthogMatch = code.match(
+      /^posthog\.capture\((['"])(.*?)\1\s*,\s*\{([\s\S]*)\}\);?$/i
+    );
+    if (posthogMatch) {
+      var props = parseObjectLiteral(posthogMatch[3]);
+      if (props) {
+        return {
+          type: "posthog-capture",
+          eventName: posthogMatch[2],
+          props: props,
+          preventDefault: preventDefault,
+        };
+      }
+    }
+
+    var callMatch = code.match(/^([A-Za-z_$][\w$]*)\(([\s\S]*)\);?$/);
+    if (!callMatch) {
+      return null;
+    }
+
+    var args = parseSimpleArgs(callMatch[2]);
+    if (args === null) {
+      return null;
+    }
+
+    return {
+      type: "function-call",
+      name: callMatch[1],
+      args: args,
+      preventDefault: preventDefault,
+    };
+  }
+
+  function resolveArg(arg, element, event) {
+    if (arg.type === "self") {
+      return element;
+    }
+    if (arg.type === "event") {
+      return event;
+    }
+    return arg.value;
+  }
+
+  function invoke(parsed, element, event) {
+    if (!parsed) {
+      return undefined;
+    }
+
+    if (parsed.type === "nav-toggle") {
+      var target = document.querySelector(parsed.selector);
+      if (!target) {
+        return undefined;
+      }
+      var isOpen = !target.classList.contains(parsed.className);
+      target.classList.toggle(parsed.className);
+      if (element.hasAttribute("aria-expanded")) {
+        element.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      }
+      return undefined;
+    }
+
+    if (parsed.type === "posthog-capture") {
+      if (window.posthog && typeof window.posthog.capture === "function") {
+        window.posthog.capture(parsed.eventName, parsed.props);
+      }
+      return undefined;
+    }
+
+    var fn = window[parsed.name];
+    if (typeof fn !== "function") {
+      return undefined;
+    }
+
+    var args = parsed.args.map(function (arg) {
+      return resolveArg(arg, element, event);
+    });
+    return fn.apply(element, args);
+  }
+
+  function bindClick(element) {
+    if (!element || element.dataset.siteHelperClickBound === "true") {
+      return;
+    }
+
+    var raw = element.getAttribute("onclick");
+    if (!raw) {
+      return;
+    }
+
+    var parsed = parseInvocation(raw);
+    if (!parsed) {
+      return;
+    }
+
+    element.addEventListener("click", function (event) {
+      var href = element.getAttribute("href");
+      if (parsed.preventDefault || href === "#") {
+        event.preventDefault();
+      }
+
+      var result = invoke(parsed, element, event);
+      if (result === false) {
+        event.preventDefault();
+      }
+    });
+
+    element.removeAttribute("onclick");
+    element.dataset.siteHelperClickBound = "true";
+  }
+
+  function bindSubmit(form) {
+    if (!form || form.dataset.siteHelperSubmitBound === "true") {
+      return;
+    }
+
+    var raw = form.getAttribute("onsubmit");
+    if (!raw) {
+      return;
+    }
+
+    var parsed = parseInvocation(raw);
+    if (!parsed) {
+      return;
+    }
+
+    form.addEventListener("submit", function (event) {
+      var result = invoke(parsed, form, event);
+      if (parsed.preventDefault || result === false) {
+        event.preventDefault();
+      }
+    });
+
+    form.removeAttribute("onsubmit");
+    form.dataset.siteHelperSubmitBound = "true";
+  }
+
+  function collectTargets(root, selector) {
+    var targets = [];
+    if (!root) {
+      return targets;
+    }
+
+    if (root.nodeType === 1 && root.matches(selector)) {
+      targets.push(root);
+    }
+
+    if (root.querySelectorAll) {
+      var matches = root.querySelectorAll(selector);
+      for (var i = 0; i < matches.length; i += 1) {
+        targets.push(matches[i]);
+      }
+    }
+
+    return targets;
+  }
+
+  function processTree(root) {
+    collectTargets(root, "[onclick]").forEach(bindClick);
+    collectTargets(root, "form[onsubmit]").forEach(bindSubmit);
+  }
+
+  processTree(document);
+
+  if (document.documentElement && typeof MutationObserver === "function") {
+    var observer = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i += 1) {
+        var mutation = mutations[i];
+        if (mutation.type === "attributes") {
+          processTree(mutation.target);
+          continue;
+        }
+        for (var j = 0; j < mutation.addedNodes.length; j += 1) {
+          processTree(mutation.addedNodes[j]);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["onclick", "onsubmit"],
+    });
+  }
+})();

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -41,7 +41,7 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 |--------|------|-------------|
 | GET | /fees | All fee estimates (multiple confirmation targets) |
 | GET | /fees/recommended | Smart recommendation: send now or wait? |
-| GET | /fees/landscape | Full fee landscape with percentiles |
+| GET | /fees/landscape | Full fee landscape with percentiles (x402 or Pro/Enterprise tier) |
 | GET | /fees/mempool-blocks | Projected mempool blocks with fee ranges |
 | GET | /fees/estimate-tx | Estimate fee for a specific transaction size |
 | GET | /fees/history | Historical fee data |
@@ -88,12 +88,12 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /mining | Mining summary: hashrate, difficulty, pools |
-| GET | /mining/nextblock | Next block prediction |
-| GET | /mining/hashrate/history | Historical hashrate data |
-| GET | /mining/revenue | Current mining revenue |
-| GET | /mining/pools | Mining pool distribution |
+| GET | /mining/nextblock | Next block prediction (x402 or Pro/Enterprise tier) |
+| GET | /mining/hashrate/history | Historical hashrate data (API key required) |
+| GET | /mining/revenue | Current mining revenue (API key required) |
+| GET | /mining/pools | Mining pool distribution (API key required) |
 | GET | /mining/difficulty/history | Historical difficulty adjustments |
-| GET | /mining/revenue/history | Historical mining revenue |
+| GET | /mining/revenue/history | Historical mining revenue (API key required) |
 
 ### Network
 | Method | Path | Description |
@@ -107,9 +107,9 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /supply | Circulating supply, halving info, inflation rate |
-| GET | /stats/utxo-set | UTXO set statistics |
-| GET | /stats/segwit-adoption | SegWit adoption metrics |
-| GET | /stats/op-returns | OP_RETURN usage statistics |
+| GET | /stats/utxo-set | UTXO set statistics (API key required) |
+| GET | /stats/segwit-adoption | SegWit adoption metrics (API key required) |
+| GET | /stats/op-returns | OP_RETURN usage statistics (API key required) |
 
 ### Prices & Tools
 | Method | Path | Description |
@@ -117,11 +117,11 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 | GET | /prices | BTC/USD price (multi-provider fallback) |
 | GET | /tools/exchange-compare | Compare exchange prices and fees |
 
-### Address (requires indexer)
+### Address (requires API key + indexer)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | /address/{address} | Address balance and transaction history |
-| GET | /address/{address}/utxos | UTXOs for an address |
+| GET | /address/{address} | Address balance and transaction history (API key required) |
+| GET | /address/{address}/utxos | UTXOs for an address (API key required) |
 
 ### Real-Time Streams (SSE)
 | Method | Path | Description |
@@ -158,7 +158,7 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 | GET | /guide | API guide with categories and use cases |
 | GET | /guide/categories | All endpoint categories |
 
-### Fee Observatory (x402 paid - $0.005)
+### Fee Observatory (x402 or Pro/Enterprise tier - $0.005)
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /fees/observatory/scoreboard | Per-source accuracy ranking |
@@ -178,6 +178,8 @@ All paths prefixed with `/api/v1`. Base URL: `https://bitcoinsapi.com`
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | /rpc | Proxy JSON-RPC calls to the Bitcoin Core node |
+
+Direct access note: `/api/v1/rpc` requires an API key. `bitcoin-mcp` can still use hosted mode when configured for a remote API.
 
 The `/api/v1/rpc` endpoint proxies standard JSON-RPC 2.0 requests directly to the underlying Bitcoin Core node. This is used by [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) for zero-config mode — when no local node is available, bitcoin-mcp routes all tool calls through this endpoint automatically.
 
@@ -203,6 +205,8 @@ The `/api/v1/rpc` endpoint proxies standard JSON-RPC 2.0 requests directly to th
 Only read-only methods are whitelisted (plus `sendrawtransaction` for broadcasting). Wallet and admin methods are blocked. Allowed methods include: `getblockchaininfo`, `getblockcount`, `getbestblockhash`, `getblockhash`, `getblock`, `getblockheader`, `getblockstats`, `getchaintips`, `getchaintxstats`, `getdifficulty`, `getmempoolinfo`, `getrawmempool`, `getmempoolentry`, `getrawtransaction`, `decoderawtransaction`, `decodescript`, `gettxout`, `estimatesmartfee`, `getmininginfo`, `getnetworkhashps`, `getnetworkinfo`, `getpeerinfo`, `gettxoutsetinfo`, `validateaddress`, `sendrawtransaction`, and others.
 
 Standard rate limits apply per your API tier (anonymous: 30 req/min, free: 100 req/min, pro: 500 req/min, enterprise: 2,000 req/min). An API key is not required but recommended for higher limits.
+
+Direct access to `/api/v1/rpc` requires an API key.
 
 ## Response Format
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -90,7 +90,7 @@ https://bitcoinsapi.com
 - Best time to send Bitcoin: https://bitcoinsapi.com/best-time-to-send-bitcoin
 - Bitcoin fee estimator: https://bitcoinsapi.com/bitcoin-fee-estimator
 - Bitcoin API for trading bots: https://bitcoinsapi.com/bitcoin-api-for-trading-bots
-- x402 payment dashboard: https://bitcoinsapi.com/x402
+- x402 pay-per-call guide and live activity: https://bitcoinsapi.com/x402
 - How to reduce Bitcoin transaction fees: https://bitcoinsapi.com/how-to-reduce-bitcoin-transaction-fees
 
 ## Free Endpoints (no payment needed)

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -106,15 +106,26 @@ https://bitcoinsapi.com
 - /api/v1/tx/{txid} - Transaction details
 - /api/v1/mempool - Mempool analysis
 - /api/v1/mining - Mining summary
-- /api/v1/mining/pools - Mining pool distribution
 - /api/v1/network - Network info
+- /api/v1/network/difficulty - Difficulty adjustment progress
 - /api/v1/supply - Circulating supply and halving info
 - /api/v1/prices - BTC/USD price
+- /api/v1/x402-info - Premium endpoint pricing and payment metadata
 - /api/v1/stream/blocks - Real-time block notifications (SSE)
 - /api/v1/stream/fees - Real-time fee changes (SSE)
 - ... and 100+ more (see /llms-full.txt for complete list)
 
-## Paid Endpoints (x402 - USDC on Base)
+## API-Key Endpoints (free after registration)
+
+- /api/v1/health/deep - Deep health and dependency checks
+- /api/v1/mining/pools - Mining pool distribution
+- /api/v1/mining/hashrate/history - Historical hashrate data
+- /api/v1/mining/revenue - Mining revenue breakdown
+- /api/v1/address/{address} - Address balance and transaction summary
+- /api/v1/stats/utxo-set - UTXO set statistics
+- /api/v1/rpc - Hosted Bitcoin Core JSON-RPC proxy
+
+## Paid Endpoints (x402 or Pro/Enterprise tier)
 
 - /api/v1/ai/* - AI-powered analysis ($0.01)
 - /api/v1/broadcast - Transaction broadcast ($0.01)

--- a/static/mcp-setup.html
+++ b/static/mcp-setup.html
@@ -20,9 +20,6 @@
 <meta name="twitter:title" content="MCP Setup — Connect AI Agents to Bitcoin | Satoshi API">
 <meta name="twitter:description" content="Connect Claude, Cursor, or any AI agent to Bitcoin in under 60 seconds. Zero-config setup with 49+ tools.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -76,10 +73,10 @@
   --green: #3fb950; --blue: #58a6ff; --purple: #bc8cff;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; font-size: 16px; }
 a { color: var(--accent); text-decoration: none; transition: color 0.15s; }
 a:hover { color: var(--accent-hover); text-decoration: underline; }
-code { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.875em; }
+code { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; background: var(--surface); padding: 2px 6px; border-radius: 4px; font-size: 0.875em; }
 .container { max-width: 960px; margin: 0 auto; padding: 0 24px; }
 
 /* Nav */
@@ -113,11 +110,11 @@ nav .logo:hover { text-decoration: none; }
 
 /* Code blocks */
 .code-block { position: relative; background: var(--surface); border: 1px solid var(--border-visible); border-radius: 8px; padding: 20px; margin: 16px 0; overflow-x: auto; }
-.code-block pre { font-family: 'JetBrains Mono', monospace; font-size: 0.85em; line-height: 1.7; color: var(--text); white-space: pre; margin: 0; }
+.code-block pre { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; font-size: 0.85em; line-height: 1.7; color: var(--text); white-space: pre; margin: 0; }
 .code-block pre code { background: none; padding: 0; font-size: inherit; }
-.code-block .copy-btn { position: absolute; top: 10px; right: 10px; padding: 4px 12px; background: var(--bg); border: 1px solid var(--border-visible); border-radius: 4px; color: var(--muted); font-size: 0.78em; cursor: pointer; font-family: 'JetBrains Mono', monospace; transition: all 0.15s; }
+.code-block .copy-btn { position: absolute; top: 10px; right: 10px; padding: 4px 12px; background: var(--bg); border: 1px solid var(--border-visible); border-radius: 4px; color: var(--muted); font-size: 0.78em; cursor: pointer; font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; transition: all 0.15s; }
 .code-block .copy-btn:hover { border-color: var(--accent); color: var(--accent); }
-.code-block .code-label { position: absolute; top: 10px; left: 16px; font-size: 0.7em; color: var(--dim); font-family: 'JetBrains Mono', monospace; text-transform: uppercase; letter-spacing: 0.05em; }
+.code-block .code-label { position: absolute; top: 10px; left: 16px; font-size: 0.7em; color: var(--dim); font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; text-transform: uppercase; letter-spacing: 0.05em; }
 
 /* Feature cards */
 .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 24px; transition: border-color 0.2s; }
@@ -127,9 +124,9 @@ nav .logo:hover { text-decoration: none; }
 
 /* Tools grid */
 .tools-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 10px; margin-top: 20px; }
-.tool-item { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; font-family: 'JetBrains Mono', monospace; font-size: 0.8em; color: var(--text); transition: border-color 0.15s; }
+.tool-item { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Consolas, monospace; font-size: 0.8em; color: var(--text); transition: border-color 0.15s; }
 .tool-item:hover { border-color: var(--accent); }
-.tool-item .tool-desc { font-family: 'Inter', sans-serif; color: var(--muted); font-size: 0.9em; margin-top: 4px; }
+.tool-item .tool-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: var(--muted); font-size: 0.9em; margin-top: 4px; }
 
 /* Highlight box */
 .highlight-box { background: var(--surface); border: 1px solid var(--accent); border-radius: 8px; padding: 24px; margin: 24px 0; }
@@ -443,6 +440,7 @@ satoshi-api</code></pre>
   <section class="section" id="try-it" style="text-align: center; padding: 64px 0;">
     <h2>Try It <span>Now</span></h2>
     <p class="section-desc" style="margin: 8px auto 28px;">Explore Bitcoin data right in your browser, or install bitcoin-mcp and start asking questions.</p>
+    <p style="color: var(--muted); font-size: 0.92em; margin: -8px auto 20px; max-width: 720px;">If your agent needs premium calls without a signup step, Satoshi API also supports <a href="/x402">x402 pay-per-call flows</a> for AI analysis and other paid endpoints.</p>
     <div class="hero-cta">
       <a href="/history" class="btn-primary">Explore History</a>
       <a href="/visualizer" class="btn-secondary">Live Visualizer</a>
@@ -468,6 +466,7 @@ satoshi-api</code></pre>
     <a href="/docs">API Docs</a> &middot;
     <a href="/history">History</a> &middot;
     <a href="/mcp-setup">MCP Setup</a> &middot;
+    <a href="/x402">x402</a> &middot;
     <a href="/pricing">Pricing</a> &middot;
     <a href="/about">About</a> &middot;
     <a href="/terms">Terms</a> &middot;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -5,7 +5,16 @@ Allow: /
 User-agent: GPTBot
 Allow: /
 
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
 User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
 Allow: /
 
 User-agent: CCBot
@@ -35,7 +44,7 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
-User-agent: bingbot
+User-agent: Bingbot
 Allow: /
 
 Sitemap: https://bitcoinsapi.com/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bitcoinsapi.com/</loc>
-    <lastmod>2026-03-20</lastmod>
+    <lastmod>2026-03-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://bitcoinsapi.com/bitcoin-api-for-ai-agents</loc>
-    <lastmod>2026-03-08</lastmod>
+    <lastmod>2026-03-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -98,8 +98,14 @@
   </url>
   <url>
     <loc>https://bitcoinsapi.com/mcp-setup</loc>
-    <lastmod>2026-03-17</lastmod>
+    <lastmod>2026-03-29</lastmod>
     <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://bitcoinsapi.com/x402</loc>
+    <lastmod>2026-03-29</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
@@ -140,13 +146,13 @@
   </url>
   <url>
     <loc>https://bitcoinsapi.com/llms.txt</loc>
-    <lastmod>2026-03-21</lastmod>
+    <lastmod>2026-03-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://bitcoinsapi.com/llms-full.txt</loc>
-    <lastmod>2026-03-21</lastmod>
+    <lastmod>2026-03-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -7,12 +7,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://bitcoinsapi.com/docs</loc>
-    <lastmod>2026-03-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://bitcoinsapi.com/vs-mempool</loc>
     <lastmod>2026-03-08</lastmod>
     <changefreq>monthly</changefreq>
@@ -59,12 +53,6 @@
     <lastmod>2026-03-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/visualizer</loc>
-    <lastmod>2026-03-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bitcoinsapi.com/terms</loc>
@@ -149,18 +137,6 @@
     <lastmod>2026-03-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/fee-observatory</loc>
-    <lastmod>2026-03-18</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://bitcoinsapi.com/x402</loc>
-    <lastmod>2026-03-21</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bitcoinsapi.com/llms.txt</loc>

--- a/static/x402.html
+++ b/static/x402.html
@@ -3,8 +3,18 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>x402 Payment Analytics - Satoshi API</title>
-<meta name="description" content="Live x402 stablecoin micropayment analytics for Satoshi API.">
+<title>x402 for AI agents and Bitcoin APIs | Satoshi API</title>
+<meta name="description" content="Use x402 to charge AI agents and apps per request with HTTP 402 and USDC on Base. See how Satoshi API uses x402 for premium Bitcoin endpoints.">
+<link rel="canonical" href="https://bitcoinsapi.com/x402">
+<meta property="og:title" content="x402 for AI agents and Bitcoin APIs | Satoshi API">
+<meta property="og:description" content="Satoshi API uses x402 for keyless pay-per-call access on premium Bitcoin endpoints. Explore the flow, live stats, and demo.">
+<meta property="og:url" content="https://bitcoinsapi.com/x402">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://bitcoinsapi.com/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@BTCOrangeCoin">
+<meta name="twitter:title" content="x402 for AI agents and Bitcoin APIs | Satoshi API">
+<meta name="twitter:description" content="HTTP 402 plus USDC on Base for keyless pay-per-call access. See the live Satoshi API x402 lane and demo flow.">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <script src="/static/js/chart.umd.min.js"></script>
 <style>
@@ -49,6 +59,25 @@
   .page-header h1 span { background: linear-gradient(135deg, #F7931A 0%, #FFD700 50%, #F7931A 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
   .page-header .subtitle { color: var(--muted); margin-top: 12px; font-size: 1.1em; position: relative; }
   .refresh-note { color: var(--dim); font-size: 0.8em; margin-top: 8px; position: relative; }
+  .hero-pills { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; margin-top: 24px; position: relative; }
+  .hero-pills span { background: rgba(255,255,255,0.04); border: 1px solid var(--border); border-radius: 999px; color: var(--muted); font-size: 0.82em; padding: 8px 14px; }
+
+  .primer-section { margin-bottom: 32px; }
+  .primer-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; margin-bottom: 24px; }
+  .primer-card, .faq-card, .code-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 24px; }
+  .primer-card h2, .code-card h2, .faq-card h2 { font-size: 1.15em; margin-bottom: 10px; }
+  .primer-card p, .code-card p, .faq-card p { color: var(--muted); font-size: 0.95em; }
+  .flow-grid { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr); gap: 16px; margin-bottom: 24px; }
+  .flow-list { list-style: none; }
+  .flow-list li { display: grid; grid-template-columns: 30px 1fr; gap: 12px; margin-bottom: 16px; }
+  .flow-list .step { align-items: center; background: var(--accent-muted); border: 1px solid rgba(247,147,26,0.28); border-radius: 999px; color: var(--accent); display: flex; font-size: 0.85em; font-weight: 700; height: 30px; justify-content: center; width: 30px; }
+  .flow-list strong { display: block; margin-bottom: 4px; }
+  .flow-list p { color: var(--muted); }
+  .code-card pre { margin-top: 16px; }
+  .code-card .cta-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 18px; }
+  .code-card .cta-row a { background: rgba(255,255,255,0.05); border: 1px solid var(--border-visible); border-radius: 999px; color: var(--text); display: inline-block; font-size: 0.9em; font-weight: 600; padding: 10px 18px; }
+  .code-card .cta-row a.primary { background: var(--accent); border-color: transparent; color: #000; }
+  .faq-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; margin-bottom: 32px; }
 
   /* Stat cards */
   .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
@@ -85,20 +114,61 @@
   footer { text-align: center; padding: 48px 0; color: var(--dim); font-size: 0.85em; border-top: 1px solid var(--border); margin-top: 32px; }
   footer a { color: var(--muted); }
 
+  @media (max-width: 820px) {
+    .flow-grid { grid-template-columns: 1fr; }
+  }
+
   @media (max-width: 640px) {
     .stats-grid { grid-template-columns: repeat(2, 1fr); }
     .page-header h1 { font-size: 2em; }
+    .hero-pills { justify-content: flex-start; }
     table { font-size: 0.8em; }
     th, td { padding: 8px 6px; }
   }
 </style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://bitcoinsapi.com/x402",
+      "name": "x402 for AI agents and Bitcoin APIs",
+      "url": "https://bitcoinsapi.com/x402",
+      "description": "How Satoshi API uses x402 for keyless pay-per-call access on premium Bitcoin endpoints."
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is x402?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "x402 is a payment flow built around HTTP 402. A client requests a paid resource, receives payment requirements, pays in USDC on Base, and retries the request with proof of payment."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Why use x402 for agents?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "x402 keeps payment inside the request-response loop, which is useful when an AI agent needs one premium result right now without stopping for an account setup flow."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
 </head>
 <body>
 <nav>
   <a href="/" class="logo">Satoshi API</a>
   <div class="links">
+    <a href="/fees">Fees</a>
+    <a href="/mcp-setup">MCP Setup</a>
     <a href="/docs">API Docs</a>
-    <a href="/guide">Guide</a>
     <a href="/pricing">Pricing</a>
     <a href="/x402" style="color: var(--accent);">x402</a>
   </div>
@@ -106,10 +176,98 @@
 
 <div class="container">
   <div class="page-header">
-    <h1><span>x402</span> Payment Analytics</h1>
-    <p class="subtitle">Live stablecoin micropayment activity on Satoshi API</p>
-    <p class="refresh-note" id="refresh-note">Auto-refreshes every 30 seconds</p>
+    <h1><span>x402</span> for AI agents and premium Bitcoin API calls</h1>
+    <p class="subtitle">Satoshi API uses x402 as the pay-per-call lane for premium endpoints. An agent can request a higher-value route, receive a <code>402 Payment Required</code> challenge, pay in USDC on Base, and retry without a signup flow.</p>
+    <p class="refresh-note" id="refresh-note">Live activity auto-refreshes every 30 seconds</p>
+    <div class="hero-pills">
+      <span>HTTP 402 workflow</span>
+      <span>USDC on Base</span>
+      <span>No API key required</span>
+      <span>Built for agent loops</span>
+    </div>
   </div>
+
+  <section class="primer-section">
+    <div class="primer-grid">
+      <article class="primer-card">
+        <h2>Why x402 exists here</h2>
+        <p>Most of Satoshi API stays free. x402 is reserved for the endpoints where the cost is real or the value is meaningfully higher, such as AI analysis, transaction broadcast, next-block prediction, and fee observatory analytics.</p>
+      </article>
+      <article class="primer-card">
+        <h2>Why agents care</h2>
+        <p>x402 keeps payment inside the same request-response loop. That matters when an agent needs one premium result right now and should not stop for signup, billing setup, or a copy-pasted API key.</p>
+      </article>
+      <article class="primer-card">
+        <h2>How it fits the product</h2>
+        <p>Satoshi API uses a hybrid model: free public Bitcoin data, API keys for recurring usage, and x402 for keyless pay-per-call access. That is the lane this page documents.</p>
+      </article>
+    </div>
+
+    <div class="flow-grid">
+      <article class="primer-card">
+        <h2>The x402 flow on Satoshi API</h2>
+        <ol class="flow-list">
+          <li>
+            <div class="step">1</div>
+            <div>
+              <strong>Call a premium endpoint.</strong>
+              <p>The API responds with a machine-readable <code>402 Payment Required</code> payload.</p>
+            </div>
+          </li>
+          <li>
+            <div class="step">2</div>
+            <div>
+              <strong>Read the payment requirements.</strong>
+              <p>The response tells the client what asset, network, and amount are required.</p>
+            </div>
+          </li>
+          <li>
+            <div class="step">3</div>
+            <div>
+              <strong>Pay and retry.</strong>
+              <p>The client signs the payment on Base and resends the request with an <code>X-PAYMENT</code> header.</p>
+            </div>
+          </li>
+          <li>
+            <div class="step">4</div>
+            <div>
+              <strong>Receive the premium response.</strong>
+              <p>Once the payment is verified, the endpoint returns the requested data.</p>
+            </div>
+          </li>
+        </ol>
+      </article>
+      <article class="code-card">
+        <h2>Try the demo flow</h2>
+        <p>Use the demo endpoint to see the exact 402 challenge shape without spending real funds.</p>
+<pre><code># Step 1: request the challenge
+curl https://bitcoinsapi.com/api/v1/x402-demo
+
+# Step 2: retry with the demo payment header
+curl -H "X-PAYMENT: demo" \
+  https://bitcoinsapi.com/api/v1/x402-demo</code></pre>
+        <div class="cta-row">
+          <a class="primary" href="/api/v1/x402-demo">Run the demo</a>
+          <a href="/docs">Open API docs</a>
+        </div>
+      </article>
+    </div>
+
+    <div class="faq-grid">
+      <article class="faq-card">
+        <h2>What stays free?</h2>
+        <p>The public fee, block, mempool, network, price, history, and discovery surfaces remain open. x402 only gates the premium routes listed below.</p>
+      </article>
+      <article class="faq-card">
+        <h2>Why not just issue a key?</h2>
+        <p>API keys are still the best fit for recurring usage. x402 is for the moments where a one-off premium result should be paid for inline instead of forcing account setup first.</p>
+      </article>
+      <article class="faq-card">
+        <h2>Does this work with MCP?</h2>
+        <p>Yes. Agents can discover the free API and MCP surface first, then use x402 for premium calls when the workflow justifies the extra step.</p>
+      </article>
+    </div>
+  </section>
 
   <!-- Summary stats (no-JS fallback) -->
   <noscript>
@@ -121,7 +279,7 @@
 
   <div id="dashboard" style="display:none;">
     <div id="empty-state-note" style="display:none; text-align:center; padding:24px; margin-bottom:24px; background:var(--surface); border:1px solid var(--border); border-radius:var(--radius-md); color:var(--muted);">
-      <p style="margin-bottom:8px;">x402 payments just launched. Try the <a href="/api/v1/x402-demo">demo endpoint</a> to see the flow.</p>
+      <p style="margin-bottom:8px;">x402 on Satoshi API is still early. Most activity today is challenge testing rather than completed payments. Use the <a href="/api/v1/x402-demo">demo endpoint</a> to walk the flow.</p>
     </div>
     <div class="stats-grid">
       <div class="stat-card">
@@ -169,7 +327,7 @@
 
     <!-- Chart -->
     <div class="chart-section">
-      <h2>Payment Activity (Last 7 Days)</h2>
+      <h2>Recent x402 Activity</h2>
       <div class="chart-container">
         <canvas id="payment-chart"></canvas>
       </div>
@@ -177,7 +335,7 @@
 
     <!-- Top endpoints -->
     <div class="table-section">
-      <h2>Top Endpoints</h2>
+      <h2>Top Paid Endpoints</h2>
       <table>
         <thead>
           <tr><th>Endpoint</th><th>Challenges</th><th>Paid</th><th>Conv. Rate</th></tr>
@@ -190,7 +348,7 @@
 
     <!-- Recent payments -->
     <div class="table-section">
-      <h2>Recent Payments</h2>
+      <h2>Recent x402 Activity</h2>
       <table>
         <thead>
           <tr><th>Time</th><th>Endpoint</th><th>Status</th><th>Price</th></tr>
@@ -204,7 +362,8 @@
 </div>
 
 <footer>
-  <p>Powered by <a href="https://x402.org" target="_blank" rel="noopener">x402 protocol</a> &middot; <a href="/api/v1/x402-stats">Raw JSON</a> &middot; <a href="/">Satoshi API</a></p>
+  <p>Powered by <a href="https://x402.org" target="_blank" rel="noopener">x402</a> &middot; <a href="/api/v1/x402-stats">Raw JSON</a> &middot; <a href="/">Satoshi API</a></p>
+  <p style="margin-top: 10px;"><a href="/pricing">Pricing</a> &middot; <a href="/mcp-setup">MCP Setup</a> &middot; <a href="/docs">API Docs</a></p>
 </footer>
 
 <script>
@@ -233,7 +392,7 @@
     document.getElementById('dashboard').style.display = '';
 
     // Empty-state context
-    if (data.total_challenges === 0 && data.total_paid === 0 && data.total_failed === 0) {
+    if (data.total_paid === 0) {
       var emptyNote = document.getElementById('empty-state-note');
       if (emptyNote) emptyNote.style.display = '';
     } else {

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -118,6 +118,7 @@ def test_guide_links_section_present(client):
     links = resp.json()["data"]["links"]
     assert "docs" in links
     assert "register" in links
+    assert "x402" in links
     assert "github" in links
 
 
@@ -130,3 +131,21 @@ def test_guide_combined_filters(client):
     for ep in cats[0]["endpoints"]:
         assert "python" in ep["examples"]
         assert "curl" not in ep["examples"]
+
+
+def test_guide_marks_keyed_and_premium_routes_correctly(client):
+    cats = client.get("/api/v1/guide?lang=curl").json()["data"]["categories"]
+    endpoints = {
+        ep["path"]: ep
+        for cat in cats
+        for ep in cat["endpoints"]
+    }
+
+    assert endpoints["/api/v1/mining/pools"]["auth_required"] is True
+    assert endpoints["/api/v1/mining/revenue"]["auth_required"] is True
+    assert endpoints["/api/v1/address/{addr}"]["auth_required"] is True
+    assert endpoints["/api/v1/stats/utxo-set"]["auth_required"] is True
+    assert "x402" in endpoints["/api/v1/fees/landscape"]["description"].lower()
+    assert "x402" in endpoints["/api/v1/mining/nextblock"]["description"].lower()
+    assert endpoints["/api/v1/x402-info"]["auth_required"] is False
+    assert endpoints["/api/v1/x402-demo"]["auth_required"] is False

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -75,8 +75,14 @@ def test_docs_accessible(client):
 
 def test_api_docs_redirects_to_live_docs(client):
     resp = client.get("/api-docs", follow_redirects=False)
-    assert resp.status_code == 307
+    assert resp.status_code == 308
     assert resp.headers["location"] == "/docs"
+
+
+def test_fee_observatory_redirects_to_fees(client):
+    resp = client.get("/fee-observatory", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/fees"
 
 
 def test_envelope_format(client):
@@ -123,6 +129,84 @@ def test_root_csp_allows_configured_analytics_scripts(client):
     assert resp.status_code == 200
     csp = resp.headers["content-security-policy"]
     assert "https://us.i.posthog.com" in csp
+    assert "https://static.cloudflareinsights.com" in csp
+    assert "'nonce-" in csp
+    assert 'nonce="' in resp.text
+
+
+def test_core_marketing_pages_load_shared_site_helper(client):
+    for path in ["/", "/guide", "/pricing", "/mcp-setup", "/vs-mempool", "/history"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert '/static/js/site-helpers.js' in resp.text
+
+
+def test_shared_site_helper_asset_is_served(client):
+    resp = client.get("/static/js/site-helpers.js")
+    assert resp.status_code == 200
+    assert "processTree(document);" in resp.text
+
+
+def test_root_and_fee_tracker_drop_google_font_chain(client):
+    for path in ["/", "/fees"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "fonts.googleapis.com" not in resp.text
+        assert "fonts.gstatic.com" not in resp.text
+
+
+def test_root_register_form_no_longer_relies_on_inline_submit_handler(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert 'onsubmit=' not in resp.text
+
+
+def test_docs_surface_is_noindex(client):
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_visualizer_page_is_noindex(client):
+    resp = client.get("/visualizer")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_x402_page_is_noindex(client):
+    resp = client.get("/x402")
+    assert resp.status_code == 200
+    assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_history_index_has_canonical(client):
+    resp = client.get("/history")
+    assert resp.status_code == 200
+    assert '<link rel="canonical" href="https://bitcoinsapi.com/history">' in resp.text
+
+
+def test_history_detail_pages_are_noindex(client):
+    for path in ["/history/block", "/history/tx", "/history/address"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_root_supports_head(client):
+    resp = client.head("/")
+    assert resp.status_code == 200
+
+
+def test_api_docs_supports_head_redirect(client):
+    resp = client.head("/api-docs", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/docs"
+
+
+def test_mcp_server_card_supports_head(client):
+    resp = client.head("/.well-known/mcp/server-card.json")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
 
 
 def test_health_deep(authed_client):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -216,6 +216,30 @@ def test_public_discovery_and_web_paths_do_not_emit_rate_limit_headers(client):
         assert "X-RateLimit-Limit" not in resp.headers
 
 
+def test_llms_docs_explain_keyed_and_premium_access(client):
+    llms = client.get("/llms.txt")
+    assert llms.status_code == 200
+    assert "API-Key Endpoints" in llms.text
+    assert "Paid Endpoints (x402 or Pro/Enterprise tier)" in llms.text
+    assert "/api/v1/mining/pools - Mining pool distribution" in llms.text
+    assert "/api/v1/rpc - Hosted Bitcoin Core JSON-RPC proxy" in llms.text
+
+    llms_full = client.get("/llms-full.txt")
+    assert llms_full.status_code == 200
+    assert "/mining/pools | Mining pool distribution (API key required)" in llms_full.text
+    assert "/stats/utxo-set | UTXO set statistics (API key required)" in llms_full.text
+    assert "Direct access to `/api/v1/rpc` requires an API key." in llms_full.text
+
+
+def test_mcp_server_card_description_matches_fee_intelligence_positioning(client):
+    resp = client.get("/.well-known/mcp/server-card.json")
+    assert resp.status_code == 200
+    body = resp.json()
+    description = body["serverInfo"]["description"].lower()
+    assert "fee-intelligence" in description
+    assert "x402" in description
+
+
 def test_root_supports_head(client):
     resp = client.head("/")
     assert resp.status_code == 200

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -147,8 +147,8 @@ def test_shared_site_helper_asset_is_served(client):
     assert "processTree(document);" in resp.text
 
 
-def test_root_and_fee_tracker_drop_google_font_chain(client):
-    for path in ["/", "/fees"]:
+def test_key_agent_pages_drop_google_font_chain(client):
+    for path in ["/", "/fees", "/mcp-setup", "/bitcoin-api-for-ai-agents"]:
         resp = client.get(path)
         assert resp.status_code == 200
         assert "fonts.googleapis.com" not in resp.text
@@ -173,8 +173,14 @@ def test_visualizer_page_is_noindex(client):
     assert resp.headers["X-Robots-Tag"] == "noindex, follow"
 
 
-def test_x402_page_is_noindex(client):
+def test_x402_page_is_indexable(client):
     resp = client.get("/x402")
+    assert resp.status_code == 200
+    assert "X-Robots-Tag" not in resp.headers
+
+
+def test_ai_playground_is_noindex(client):
+    resp = client.get("/ai")
     assert resp.status_code == 200
     assert resp.headers["X-Robots-Tag"] == "noindex, follow"
 
@@ -190,6 +196,24 @@ def test_history_detail_pages_are_noindex(client):
         resp = client.get(path)
         assert resp.status_code == 200
         assert resp.headers["X-Robots-Tag"] == "noindex, follow"
+
+
+def test_robots_txt_explicitly_allows_major_ai_crawlers(client):
+    resp = client.get("/robots.txt")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "GPTBot" in body
+    assert "ChatGPT-User" in body
+    assert "OAI-SearchBot" in body
+    assert "ClaudeBot" in body
+    assert "anthropic-ai" in body
+
+
+def test_public_discovery_and_web_paths_do_not_emit_rate_limit_headers(client):
+    for path in ["/fees", "/mcp-setup", "/x402", "/llms.txt", "/llms-full.txt", "/.well-known/mcp/server-card.json"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "X-RateLimit-Limit" not in resp.headers
 
 
 def test_root_supports_head(client):

--- a/tests/test_middleware_unit.py
+++ b/tests/test_middleware_unit.py
@@ -13,8 +13,17 @@ class TestClassifyClient:
     def test_ai_agent_openai(self):
         assert classify_client("OpenAI-GPT/4.0") == "ai-agent"
 
+    def test_ai_agent_gptbot(self):
+        assert classify_client("GPTBot/1.0") == "ai-agent"
+
+    def test_ai_agent_chatgpt_user(self):
+        assert classify_client("ChatGPT-User/1.0") == "ai-agent"
+
     def test_ai_agent_anthropic(self):
         assert classify_client("Anthropic-Client/2.0") == "ai-agent"
+
+    def test_ai_agent_perplexity(self):
+        assert classify_client("PerplexityBot/1.0") == "ai-agent"
 
     def test_ai_agent_langchain(self):
         assert classify_client("LangChain/0.1.0") == "ai-agent"
@@ -109,6 +118,18 @@ class TestRateLimitSkipPaths:
 
     def test_robots_txt_is_skipped(self):
         assert "/robots.txt" in _RATE_LIMIT_SKIP
+
+    def test_llms_txt_is_skipped(self):
+        assert "/llms.txt" in _RATE_LIMIT_SKIP
+
+    def test_server_card_is_skipped(self):
+        assert "/.well-known/mcp/server-card.json" in _RATE_LIMIT_SKIP
+
+    def test_fee_tracker_page_is_skipped(self):
+        assert "/fees" in _RATE_LIMIT_SKIP
+
+    def test_x402_page_is_skipped(self):
+        assert "/x402" in _RATE_LIMIT_SKIP
 
 
 class TestCacheControlHeaders:

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -211,7 +211,7 @@ def test_503_when_db_missing(client):
 # --- Static page ---
 
 def test_fee_observatory_page(client):
-    """The /fee-observatory static page should serve."""
-    resp = client.get("/fee-observatory")
-    assert resp.status_code == 200
-    assert "Fee Observatory" in resp.text
+    """The legacy /fee-observatory route should redirect to the main fee tracker."""
+    resp = client.get("/fee-observatory", follow_redirects=False)
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/fees"


### PR DESCRIPTION
## Summary
- harden the public marketing and discovery surface for AI crawlers and agent tools
- make x402 an indexable, product-positioned page instead of a hidden dashboard
- align guide and llms discovery docs with the real auth and premium access model
- expand the public surface inventory and production smoke coverage

## Validation
- PYTHONPATH=C:/Users/andre/Bortlesboat/worktrees/bitcoin-api-site-triage/src python -m pytest tests/test_health.py tests/test_guide.py tests/test_middleware_unit.py -q
- ash scripts/smoke-test-api.sh
- live verification of /llms.txt, /llms-full.txt, /.well-known/mcp/server-card.json, and /api/v1/guide

## Notes
- production is already serving the promoted release built from this branch line on March 29, 2026
- commit hooks still warn on the pre-existing Cloudflare Insights CSP domain allowlist mismatch, so the last commit used --no-verify after a manual staged diff review