### PR TITLE
docs: add Raspberry Pi self-hosting guidance

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,21 +1,103 @@
 # Self-Hosting Guide
 
-Deploy the Satoshi API on your own infrastructure with a full Bitcoin Core node.
+Deploy Satoshi API on hardware you control, backed by your own Bitcoin Core node. The goal is to keep fee checks, transaction lookups, address research, and agent requests out of centralized Bitcoin API logs.
 
 ## Prerequisites
 
-- **Bitcoin Core** fully synced with `txindex=1` enabled
+- **Bitcoin Core** synced enough for the mode you choose below
 - **Python 3.10+** (or Docker)
-- **Linux server** (Ubuntu 22.04+ recommended) with 4+ GB RAM
-- A domain name (for Cloudflare Tunnel)
+- **Linux server** or **Raspberry Pi 4/5** with 4+ GB RAM
+- **SSD storage** strongly recommended for Raspberry Pi deployments
+- A domain name if you want public HTTPS through Cloudflare Tunnel
+
+## Deployment Modes
+
+Choose the mode that matches your hardware and privacy needs.
+
+| Mode | Bitcoin Core settings | Best for | Tradeoff |
+| ---- | --------------------- | -------- | -------- |
+| Low-storage Pi mode | `prune=55000`, no `txindex` | Fee intelligence, mempool status, block data, transaction decode/broadcast, local agent access | Full historical transaction and address-history lookups are limited until compact indexing is complete |
+| Full lookup mode | `txindex=1`, no pruning | Arbitrary historical transaction lookups and richer API coverage | Requires much more disk and a longer initial sync |
+
+Do not enable both `prune` and `txindex=1` for the same node. If you start in low-storage mode, you can still use Satoshi API for the highest-value fee and network endpoints while the compact address-indexer roadmap closes the remaining address-history gap.
+
+## Privacy Model
+
+Centralized Bitcoin data APIs can observe sensitive metadata even when they never custody funds:
+
+- which addresses or transactions you research
+- when you check them
+- which IP/network makes the request
+- repeated query patterns that can link wallets, devices, or workflows
+- whether you appear to be preparing to transact during a sensitive window
+
+A self-hosted Satoshi API instance reduces that exposure by keeping Bitcoin data queries on hardware you control. The API talks to your Bitcoin node over local RPC, so address lookups, fee checks, transaction explanations, and agent requests do not need third-party API accounts.
+
+This does not make Bitcoin itself private. Public-chain activity remains public, network-level privacy still depends on your node and wallet setup, and exposing the API publicly can create new logs unless access is restricted. The practical goal is narrower: remove centralized Bitcoin API query logs from your workflow.
+
+## Raspberry Pi Quick Path
+
+Use this path for a Raspberry Pi 4/5 or comparable ARM64 device.
+
+### Hardware target
+
+- Raspberry Pi 4 or 5
+- 4 GB RAM minimum; 8 GB preferred
+- 128 GB+ SSD for low-storage pruned mode; larger is better
+- 1 TB+ SSD if you want full lookup mode with `txindex=1`
+- 64-bit Raspberry Pi OS Lite or Ubuntu Server
+
+### Base packages
+
+```bash
+sudo apt update
+sudo apt install -y python3-venv python3-pip git curl jq ufw
+```
+
+Install and sync Bitcoin Core before starting Satoshi API. For low-storage mode, configure Bitcoin Core with pruning. For full lookup mode, use `txindex=1` and do not prune.
 
 ## 1. Bitcoin Core RPC Configuration
 
 Copy the settings from [`bitcoin-conf-example.conf`](./bitcoin-conf-example.conf) into your `bitcoin.conf` (typically `~/.bitcoin/bitcoin.conf`).
 
+### Low-storage Pi mode
+
+Use this when you want fee intelligence and core Bitcoin data on limited storage:
+
+```ini
+server=1
+prune=55000
+
+rpcuser=satoshiapi
+rpcpassword=CHANGE_ME_TO_A_STRONG_PASSWORD
+
+rpcwhitelist=satoshiapi:getblockchaininfo,getblockcount,getnetworkinfo,getmempoolinfo,estimatesmartfee,getmininginfo,getrawtransaction,gettxout,getmempoolentry,getrawmempool,getblockstats,getchaintips,decoderawtransaction,sendrawtransaction,getblocktemplate,getblockhash,getblock,getblockheader,validateaddress,gettxoutsetinfo,gettxoutproof
+
+rpcbind=127.0.0.1
+rpcallowip=127.0.0.1
+```
+
+### Full lookup mode
+
+Use this when you need arbitrary historical transaction lookup support:
+
+```ini
+server=1
+txindex=1
+
+rpcuser=satoshiapi
+rpcpassword=CHANGE_ME_TO_A_STRONG_PASSWORD
+
+rpcwhitelist=satoshiapi:getblockchaininfo,getblockcount,getnetworkinfo,getmempoolinfo,estimatesmartfee,getmininginfo,getrawtransaction,gettxout,getmempoolentry,getrawmempool,getblockstats,getchaintips,decoderawtransaction,sendrawtransaction,getblocktemplate,getblockhash,getblock,getblockheader,validateaddress,gettxoutsetinfo,gettxoutproof
+
+rpcbind=127.0.0.1
+rpcallowip=127.0.0.1
+```
+
 Key points:
 - **Change the password** in `rpcpassword` to a strong random value
-- `txindex=1` is required for transaction lookup endpoints -- if you're enabling this on an existing node, you'll need to reindex (`bitcoind -reindex`)
+- `txindex=1` is required for arbitrary historical transaction lookup endpoints
+- if you enable `txindex=1` on an existing node, you need to reindex (`bitcoind -reindex`)
 - The `rpcwhitelist` restricts the API user to only the commands the API actually needs
 - `rpcbind=127.0.0.1` ensures RPC is never exposed to the network
 
@@ -66,6 +148,21 @@ satoshi-api
 # or: bitcoin-api (both commands work)
 # -> http://localhost:9332/docs
 ```
+
+For Raspberry Pi low-storage mode, you can start with a minimal environment:
+
+```bash
+export BITCOIN_RPC_HOST=127.0.0.1
+export BITCOIN_RPC_PORT=8332
+export BITCOIN_RPC_USER=satoshiapi
+export BITCOIN_RPC_PASSWORD=YOUR_PASSWORD
+export API_HOST=127.0.0.1
+export API_PORT=9332
+
+satoshi-api
+```
+
+Keep `API_HOST=127.0.0.1` if the API is only for your own machine, Tailscale network, or Cloudflare Tunnel. Binding to all interfaces is only appropriate when you understand the network exposure.
 
 **Optional extras** -- install only what you need:
 
@@ -138,6 +235,23 @@ sudo systemctl start cloudflared
 The API can optionally integrate with Upstash Redis (persistent rate limiting), Resend (transactional email), and PostHog (landing page analytics). **All default to disabled and are not required for self-hosting.** In-memory rate limiting works fine for single-instance deployments. See `.env.production.example` for configuration details.
 
 ## 6. Monitoring
+
+### Smoke tests
+
+Run these locally after startup:
+
+```bash
+curl http://localhost:9332/api/v1/health | jq
+curl http://localhost:9332/api/v1/fees/recommended | jq
+curl http://localhost:9332/api/v1/fees/landscape | jq
+curl http://localhost:9332/api/v1/network | jq
+```
+
+If a transaction or address-history endpoint fails on a pruned node, first check whether that endpoint needs historical data unavailable in low-storage mode. The expected path is:
+
+- low-storage mode today for fee, mempool, block, network, and agent utility
+- full lookup mode when you need `txindex=1`
+- compact address indexing as the roadmap item that removes the remaining storage barrier
 
 ### UptimeRobot
 

--- a/docs/superpowers/plans/2026-04-19-merchant-funnel-implementation.md
+++ b/docs/superpowers/plans/2026-04-19-merchant-funnel-implementation.md
@@ -1,0 +1,583 @@
+# Merchant Funnel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a canonical `/facilitator` merchant landing page, turn `/x402` and `/pricing` into feeder pages, and wire the crawl + analytics surfaces so the hosted x402 facilitator is easier to discover, trust, and contact.
+
+**Architecture:** Keep the public story on `bitcoinsapi.com` and keep `facilitator.bitcoinsapi.com` as the live proof/runtime domain. This pass intentionally does not add a self-serve merchant dashboard or a new standalone facilitator microsite; it adds one canonical merchant page, small feeder changes on existing public pages, and light shared instrumentation that works with the current static-page architecture.
+
+**Tech Stack:** FastAPI static routing, static HTML pages, shared `site-helpers.js`, PostHog page instrumentation, pytest
+
+---
+
+## File Structure
+
+- Modify: `src/bitcoin_api/static_routes.py`
+  Responsibility: allow the new `/facilitator` static page without changing unrelated route behavior.
+- Modify: `src/bitcoin_api/middleware.py`
+  Responsibility: keep `/facilitator` public, pageview-logged, and crawlable without accidentally adding it to the noindex set.
+- Create: `static/facilitator.html`
+  Responsibility: canonical merchant-conversion page for the hosted x402 facilitator.
+- Modify: `static/x402.html`
+  Responsibility: keep `/x402` proof-first, but add a clear handoff to `/facilitator`.
+- Modify: `static/pricing.html`
+  Responsibility: add one facilitator callout without turning pricing into a second facilitator explainer.
+- Modify: `static/js/site-helpers.js`
+  Responsibility: add small shared support for `[data-track-event]` click instrumentation so tracking does not get duplicated inline across pages.
+- Modify: `static/sitemap.xml`
+  Responsibility: expose `/facilitator` as an indexable canonical public page.
+- Modify: `static/llms.txt`
+  Responsibility: expose `/facilitator` to lightweight AI-discovery readers.
+- Modify: `static/llms-full.txt`
+  Responsibility: add the richer merchant-page reference to the long-form AI-discovery surface.
+- Modify: `tests/test_health.py`
+  Responsibility: route, crawl, helper-asset, pricing, and sitemap regression coverage.
+- Modify: `tests/test_x402_stats.py`
+  Responsibility: x402 feeder-page assertions.
+- Modify: `tasks/todo.md`
+  Responsibility: mark plan completion and leave execution-ready tracking state.
+- Modify: `tasks/lessons.md`
+  Responsibility: capture any reusable implementation discoveries from the actual execution pass.
+
+## Scope Notes
+
+- Do **not** add a global `Facilitator` nav item in this pass. The spec explicitly prefers feeder-page handoffs first so we do not bloat the primary site tree.
+- Do **not** add `/facilitator` to `_NOINDEX_PATHS` in `src/bitcoin_api/middleware.py`. `/x402` stays noindex; `/facilitator` becomes the crawlable merchant page.
+- Reuse the existing shared helper injection model. Prefer small `data-track-event` attributes plus shared JS over new page-specific tracking code.
+
+## Chunk 1: Canonical Facilitator Surface
+
+### Task 1: Isolate the Work and Lock the Route Boundary
+
+**Files:**
+- Modify: `src/bitcoin_api/static_routes.py`
+- Modify: `src/bitcoin_api/middleware.py`
+- Modify: `tests/test_health.py`
+
+- [ ] **Step 1: Create an isolated worktree before touching implementation files**
+
+Run:
+
+```powershell
+git worktree add ../bitcoin-api-merchant-funnel -b codex/merchant-funnel
+```
+
+Expected:
+- new worktree created at `../bitcoin-api-merchant-funnel`
+- branch `codex/merchant-funnel` checked out there
+
+- [ ] **Step 2: Write the failing route and crawlability tests in `tests/test_health.py`**
+
+Add tests shaped like:
+
+```python
+def test_facilitator_page_served(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    assert "Hosted x402 facilitator" in resp.text
+
+
+def test_facilitator_page_is_indexable(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    assert "X-Robots-Tag" not in resp.headers
+    assert '<link rel="canonical" href="https://bitcoinsapi.com/facilitator">' in resp.text
+
+
+def test_facilitator_page_loads_shared_site_helper(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    assert '/static/js/site-helpers.js' in resp.text
+```
+
+- [ ] **Step 3: Run the new tests and verify they fail for the right reason**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k facilitator -v
+```
+
+Expected:
+- FAIL with `404 != 200` for `/facilitator`
+
+- [ ] **Step 4: Open the route boundary in `src/bitcoin_api/static_routes.py`**
+
+Add `"facilitator"` to the allowed static page set:
+
+```python
+allowed = {
+    ...,
+    "mcp-setup", "ai", "fees", "x402", "guides", "facilitator",
+}
+```
+
+- [ ] **Step 5: Make `/facilitator` public and pageview-logged in `src/bitcoin_api/middleware.py`**
+
+Add `/facilitator` to the public static page sets that already cover pages like `/pricing` and `/guide`:
+
+```python
+_PAGEVIEW_LOG_PATHS = {
+    ...,
+    "/pricing", "/mcp-setup", "/guide", "/facilitator",
+}
+
+_RATE_LIMIT_SKIP = {
+    ...,
+    "/terms", "/privacy", "/disclaimer", "/about", "/pricing", "/facilitator",
+    ...
+}
+```
+
+Do **not** add `/facilitator` to `_NOINDEX_PATHS`.
+
+- [ ] **Step 6: Re-run the route tests**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k facilitator -v
+```
+
+Expected:
+- still FAIL because the page file does not exist yet, or because canonical copy is missing
+
+- [ ] **Step 7: Commit the route-boundary change once the public route behavior is defined**
+
+Run:
+
+```powershell
+git add src/bitcoin_api/static_routes.py src/bitcoin_api/middleware.py tests/test_health.py
+git commit -m "feat: expose facilitator landing route"
+```
+
+### Task 2: Build the Canonical `/facilitator` Page
+
+**Files:**
+- Create: `static/facilitator.html`
+- Modify: `tests/test_health.py`
+
+- [ ] **Step 1: Extend the failing tests to pin the page's real contract**
+
+Add assertions for the exact elements the spec requires:
+
+```python
+def test_facilitator_page_contains_core_ctas_and_proof_links(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    assert 'data-track-event="facilitator_cta_docs"' in resp.text
+    assert 'data-track-event="facilitator_cta_contact"' in resp.text
+    assert 'https://facilitator.bitcoinsapi.com/status' in resp.text
+    assert 'https://facilitator.bitcoinsapi.com/.well-known/x402' in resp.text
+    assert 'https://bitcoinsapi.com/openapi.json' in resp.text
+
+
+def test_facilitator_page_contains_required_sections(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    for marker in (
+        "Live facilitator",
+        "Why Satoshi",
+        "How it works",
+        "Who this is for",
+        "Email api@bitcoinsapi.com for onboarding",
+    ):
+        assert marker in resp.text
+```
+
+- [ ] **Step 2: Run the tests and verify they fail on missing markup**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k facilitator -v
+```
+
+Expected:
+- FAIL on missing title, CTA, proof-link, or required-section assertions
+
+- [ ] **Step 3: Create `static/facilitator.html` with the canonical merchant content**
+
+Build the page with these exact sections:
+
+```html
+<title>Hosted x402 Facilitator for API Sellers - Satoshi API</title>
+<link rel="canonical" href="https://bitcoinsapi.com/facilitator">
+
+<h1>Hosted x402 facilitator for API sellers</h1>
+<p>Monetize APIs, AI tools, and MCP endpoints with USDC on Base.</p>
+
+<a href="/docs" data-track-event="facilitator_cta_docs">View integration docs</a>
+<a href="mailto:api@bitcoinsapi.com?subject=x402%20facilitator%20onboarding"
+   data-track-event="facilitator_cta_contact">Start onboarding</a>
+
+<a href="https://facilitator.bitcoinsapi.com/status">Live status</a>
+<a href="https://facilitator.bitcoinsapi.com/.well-known/x402">Facilitator well-known</a>
+<a href="https://facilitator.bitcoinsapi.com/discovery/resources">Merchant resources</a>
+<a href="https://bitcoinsapi.com/.well-known/x402">Seller well-known</a>
+<a href="https://bitcoinsapi.com/openapi.json">Paid seller OpenAPI</a>
+<a href="https://bitcoinsapi.com/api/v1/x402-info">Seller x402 info</a>
+```
+
+Content requirements:
+- hero, trust strip, "Why Satoshi", "How it works", "Proof", "Who this is for", final CTA
+- reuse the existing dark visual language from `static/x402.html` and `static/index.html`
+- keep the nav/footer conservative; do **not** introduce a new global `Facilitator` nav item
+- keep the page meaningful even if any live-proof fetch fails
+
+- [ ] **Step 4: Keep live proof additive, not required**
+
+If you add a small live-proof widget, keep the copy readable without it and limit the enhancement to trust chips or proof cards. Do not make the hero or CTA depend on JavaScript.
+
+- [ ] **Step 5: Run the facilitator-page tests again**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k facilitator -v
+```
+
+Expected:
+- PASS for the facilitator-specific tests
+
+- [ ] **Step 6: Commit the canonical page**
+
+Run:
+
+```powershell
+git add static/facilitator.html tests/test_health.py
+git commit -m "feat: add facilitator landing page"
+```
+
+## Chunk 2: Feeder Pages, Tracking, and Verification
+
+### Task 3: Turn `/x402` into a Merchant Feeder Page
+
+**Files:**
+- Modify: `static/x402.html`
+- Modify: `tests/test_x402_stats.py`
+
+- [ ] **Step 1: Add the failing feeder-page test**
+
+Add a test shaped like:
+
+```python
+def test_x402_dashboard_links_to_facilitator_page(client):
+    resp = client.get("/x402")
+    assert resp.status_code == 200
+    assert 'href="/facilitator"' in resp.text
+    assert 'data-track-event="x402_to_facilitator_click"' in resp.text
+```
+
+- [ ] **Step 2: Run the x402 page test and verify it fails**
+
+Run:
+
+```powershell
+pytest tests/test_x402_stats.py -k facilitator -v
+```
+
+Expected:
+- FAIL on missing `/facilitator` link or tracking attribute
+
+- [ ] **Step 3: Add a merchant intro + CTA near the top of `static/x402.html`**
+
+Add a short proof-first handoff block above the dashboard body:
+
+```html
+<p class="subtitle">Live stablecoin micropayment activity on Satoshi API.</p>
+<p class="merchant-intro">
+  Selling premium API or MCP endpoints? Use the hosted Satoshi x402 facilitator.
+</p>
+<a href="/facilitator" data-track-event="x402_to_facilitator_click">Use the facilitator</a>
+```
+
+Keep the rest of the page analytics-first. Do not rewrite `/x402` into a second full landing page.
+
+- [ ] **Step 4: Re-run the x402 tests**
+
+Run:
+
+```powershell
+pytest tests/test_x402_stats.py -v
+```
+
+Expected:
+- PASS for the new feeder-page assertion and existing x402 stats tests
+
+- [ ] **Step 5: Commit the x402 feeder change**
+
+Run:
+
+```powershell
+git add static/x402.html tests/test_x402_stats.py
+git commit -m "feat: link x402 dashboard to facilitator page"
+```
+
+### Task 4: Add the Pricing Handoff and Shared Tracking Hook
+
+**Files:**
+- Modify: `static/facilitator.html`
+- Modify: `static/pricing.html`
+- Modify: `static/js/site-helpers.js`
+- Modify: `tests/test_health.py`
+
+- [ ] **Step 1: Add the failing pricing + shared-helper tests**
+
+Add assertions shaped like:
+
+```python
+def test_pricing_page_links_to_facilitator(client):
+    resp = client.get("/pricing")
+    assert resp.status_code == 200
+    assert 'href="/facilitator"' in resp.text
+    assert 'data-track-event="pricing_to_facilitator_click"' in resp.text
+
+
+def test_facilitator_page_contains_page_view_event(client):
+    resp = client.get("/facilitator")
+    assert resp.status_code == 200
+    assert "facilitator_page_view" in resp.text
+
+
+def test_shared_site_helper_binds_tracked_click_targets(client):
+    resp = client.get("/static/js/site-helpers.js")
+    assert resp.status_code == 200
+    assert "bindTrackedElement" in resp.text
+    assert "[data-track-event]" in resp.text
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k "pricing_page_links_to_facilitator or tracked_click_targets" -v
+```
+
+Expected:
+- FAIL on missing pricing link, missing facilitator page-view marker, or missing helper behavior
+
+- [ ] **Step 3: Extend `static/js/site-helpers.js` to bind tracked clicks globally**
+
+Add a small shared binder that captures `data-track-event` clicks when `window.posthog.capture` exists:
+
+```javascript
+function bindTrackedElement(element) {
+  if (!element || element.dataset.siteHelperTrackedBound === "true") {
+    return;
+  }
+
+  element.addEventListener("click", function () {
+    if (window.posthog && typeof window.posthog.capture === "function") {
+      window.posthog.capture(element.dataset.trackEvent, {
+        location: element.dataset.trackLocation || "",
+        target: element.dataset.trackTarget || "",
+      });
+    }
+  });
+
+  element.dataset.siteHelperTrackedBound = "true";
+}
+```
+
+Then call it from `processTree(root)` for `[data-track-event]`.
+
+- [ ] **Step 4: Add the facilitator page-view event and the pricing handoff markup**
+
+In `static/facilitator.html`, add a guarded page-load event:
+
+```html
+<script>
+if (window.posthog && typeof window.posthog.capture === "function") {
+  window.posthog.capture("facilitator_page_view", {
+    location: "facilitator",
+    page: "/facilitator",
+  });
+}
+</script>
+```
+
+Use a concise block, not a second pricing table:
+
+```html
+<section class="enterprise">
+  <p>
+    Selling paid API or MCP endpoints? We also run a hosted x402 facilitator.
+    <a href="/facilitator"
+       data-track-event="pricing_to_facilitator_click"
+       data-track-location="pricing"
+       data-track-target="facilitator">Learn about the facilitator</a>
+  </p>
+</section>
+```
+
+Do not convert `/pricing` into a facilitator explainer. Keep it as a single handoff.
+
+- [ ] **Step 5: Re-run the health/static tests**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k "pricing_page_links_to_facilitator or facilitator_page_contains_page_view_event or tracked_click_targets or site_helper" -v
+```
+
+Expected:
+- PASS for the pricing callout, facilitator page-view marker, and helper asset assertions
+
+- [ ] **Step 6: Run a behavioral smoke check for tracked events**
+
+In a browser on `/pricing`, stub PostHog and click the pricing CTA:
+
+```javascript
+window.__trackCalls = [];
+window.posthog = {
+  capture: (event, props) => window.__trackCalls.push({ event, props }),
+};
+document.querySelector('[data-track-event="pricing_to_facilitator_click"]').click();
+window.__trackCalls;
+```
+
+Expected:
+- one captured event with `event === "pricing_to_facilitator_click"`
+- `props.location === "pricing"`
+- `props.target === "facilitator"`
+
+- [ ] **Step 7: Commit the shared tracking and pricing handoff**
+
+Run:
+
+```powershell
+git add static/facilitator.html static/pricing.html static/js/site-helpers.js tests/test_health.py
+git commit -m "feat: add facilitator pricing handoff"
+```
+
+### Task 5: Update Crawl and AI-Discovery Surfaces
+
+**Files:**
+- Modify: `static/sitemap.xml`
+- Modify: `static/llms.txt`
+- Modify: `static/llms-full.txt`
+- Modify: `tests/test_health.py`
+
+- [ ] **Step 1: Add the failing crawl-surface tests**
+
+Add tests shaped like:
+
+```python
+def test_sitemap_includes_facilitator_page(client):
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+    assert "https://bitcoinsapi.com/facilitator" in resp.text
+
+
+def test_llms_surfaces_reference_facilitator_page(client):
+    for path in ("/llms.txt", "/llms-full.txt"):
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "https://bitcoinsapi.com/facilitator" in resp.text
+```
+
+- [ ] **Step 2: Run the crawl-surface tests and verify they fail**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k "sitemap_includes_facilitator or llms_surfaces_reference_facilitator" -v
+```
+
+Expected:
+- FAIL because `/facilitator` is not yet present in the crawl/discovery text surfaces
+
+- [ ] **Step 3: Add `/facilitator` to `static/sitemap.xml`**
+
+Add a normal public-page entry, matching the format used for other indexable landing pages. Do not mark it noindex anywhere else.
+
+- [ ] **Step 4: Add `/facilitator` to `static/llms.txt` and `static/llms-full.txt`**
+
+Use concise wording that tells AI readers this is the canonical merchant landing page for the hosted x402 facilitator.
+
+- [ ] **Step 5: Re-run the crawl-surface tests**
+
+Run:
+
+```powershell
+pytest tests/test_health.py -k "sitemap_includes_facilitator or llms_surfaces_reference_facilitator" -v
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 6: Commit the crawl/discovery updates**
+
+Run:
+
+```powershell
+git add static/sitemap.xml static/llms.txt static/llms-full.txt tests/test_health.py
+git commit -m "feat: surface facilitator page in crawl assets"
+```
+
+### Task 6: Final Verification, Smoke Test, and Notes
+
+**Files:**
+- Modify: `tasks/todo.md`
+- Modify: `tasks/lessons.md`
+
+- [ ] **Step 1: Run the focused regression suite**
+
+Run:
+
+```powershell
+pytest tests/test_health.py tests/test_x402_stats.py tests/test_public_discovery_paths.py -v
+```
+
+Expected:
+- all selected tests PASS
+
+- [ ] **Step 2: Run the repo structural diagnostic required by the repo instructions**
+
+Run:
+
+```powershell
+./diagnose.sh
+```
+
+Expected:
+- no import-cycle, startup, or silo-regression errors
+
+- [ ] **Step 3: Run a manual public-page smoke pass**
+
+Check these routes in a browser:
+
+- `/facilitator`
+- `/x402`
+- `/pricing`
+- `/sitemap.xml`
+- `/llms.txt`
+
+Confirm:
+- `/facilitator` is crawlable and not tagged `noindex`
+- `/facilitator` fires `facilitator_page_view` once on load in the PostHog/network view
+- `/x402` still reads as a proof page first
+- `/pricing` only contains one facilitator handoff
+- `/x402` and `/pricing` CTA clicks emit the expected event names
+- CTA links resolve to the intended docs, email, and proof destinations
+- no console errors caused by the shared helper change
+
+- [ ] **Step 4: Update task tracking and durable lessons**
+
+In `tasks/todo.md`:
+- mark the merchant-funnel implementation plan as complete
+- add a short execution checklist if work will continue in a separate session
+
+In `tasks/lessons.md`:
+- record any real implementation discovery, especially if route logging, crawlability, or shared helper behavior behaved differently than expected
+
+- [ ] **Step 5: Commit the verification/docs pass**
+
+Run:
+
+```powershell
+git add tasks/todo.md tasks/lessons.md
+git commit -m "docs: record merchant funnel rollout verification"
+```

--- a/docs/superpowers/specs/2026-04-19-merchant-funnel-design.md
+++ b/docs/superpowers/specs/2026-04-19-merchant-funnel-design.md
@@ -1,0 +1,319 @@
+# Merchant Funnel Design
+
+Date: 2026-04-19
+Status: Drafted and approved in brainstorming; awaiting written-spec review and user signoff
+Scope: `bitcoinsapi.com` merchant-acquisition path for the hosted x402 facilitator
+
+## Summary
+
+`bitcoinsapi.com` already has the technical pieces needed to look credible in the x402 ecosystem:
+
+- a live seller surface with curated x402 discovery at `/.well-known/x402`, `/openapi.json`, and `/api/v1/x402-info`
+- a live facilitator runtime at `https://facilitator.bitcoinsapi.com` with `/status`, `/.well-known/x402`, and `/discovery/resources`
+- an x402 analytics page at `/x402`
+
+The missing piece is a canonical merchant-conversion path. Today the story is discoverable if someone already knows where to look, but the site does not yet give merchants one clear page that says what the facilitator is, why it is credible, and what to do next.
+
+This design adds that path without fragmenting the public site or creating a second competing microsite.
+
+## Goals
+
+- Create one canonical facilitator page on `bitcoinsapi.com` for merchants and ecosystem reviewers.
+- Reuse the existing seller site, trust surface, and documentation tree instead of building a second marketing site.
+- Turn the existing x402 and pricing pages into feeder pages that point toward one conversion target.
+- Preserve a clean information architecture so `/x402` remains proof-oriented and `/facilitator` remains conversion-oriented.
+- Expose live proof from the facilitator runtime without making the page depend entirely on live client-side fetches.
+- Instrument the funnel so we can measure whether interest is moving toward docs or onboarding.
+
+## Non-Goals
+
+- Building a full self-serve merchant dashboard in this pass.
+- Repositioning the homepage around x402 at the expense of the core API product.
+- Creating a separate standalone marketing site on `facilitator.bitcoinsapi.com`.
+- Expanding the facilitator protocol/runtime surface beyond what is already needed for current discovery and proof.
+
+## Current Context
+
+### Existing seller-facing surfaces
+
+- `static/x402.html` is a live payment analytics page, not a merchant onboarding page.
+- `static/pricing.html` covers hosted API, Pro, and self-hosted product pricing.
+- `src/bitcoin_api/static_routes.py` controls which public static pages can be served and which URLs redirect.
+- `src/bitcoin_api/x402_public.py` already centralizes public seller metadata for:
+  - `/api/v1/x402-info`
+  - `/api/v1/x402/pricing`
+  - `/.well-known/x402`
+  - paid-only `/openapi.json`
+
+### Existing facilitator-facing surfaces
+
+- `ops/x402-facilitator/app_factory.py` exposes:
+  - `/status`
+  - `/.well-known/x402`
+  - `/discovery/resources`
+  - `/discovery/merchant`
+  - `/supported`
+  - settlement and observability endpoints
+- `ops/x402-facilitator/facilitator_metadata.py` defines merchant resources, registry metadata, and well-known payloads.
+
+### Current gap
+
+The public tree does not include a dedicated facilitator landing page, so the link graph currently asks merchants to infer the product from proof surfaces rather than guiding them through a clear story.
+
+## Recommended Approach
+
+Build the facilitator funnel on the main `bitcoinsapi.com` site and use `facilitator.bitcoinsapi.com` as the live proof/runtime domain.
+
+This is preferred over:
+
+- putting the full funnel on `facilitator.bitcoinsapi.com`, which would split trust and duplicate site content
+- focusing first on deeper facilitator operations instead of acquisition, which helps later-stage adoption more than current discoverability
+
+## Information Architecture
+
+Each page should keep one clear job:
+
+- `/` remains the broad product homepage for Satoshi API.
+- `/pricing` remains the plan and packaging page for the core API.
+- `/x402` remains the proof-first protocol and analytics page.
+- `/facilitator` becomes the merchant conversion page for the hosted x402 facilitator.
+- `/docs`, `/openapi.json`, `/.well-known/x402`, and facilitator runtime endpoints remain documentation and proof surfaces, not primary landing pages.
+
+### Link tree
+
+The intended primary path is:
+
+`Home -> x402 -> Facilitator -> Docs or Onboarding`
+
+Supporting internal-link rules:
+
+- `/x402` should link strongly to `/facilitator`.
+- `/pricing` should include one focused facilitator callout to `/facilitator`.
+- `/facilitator` should link outward to live proof and docs.
+- Footer and sitemap may include `/facilitator`, but the site should avoid repeating facilitator links in every surface.
+
+## Proposed Public-Site Changes
+
+### 1. Add `/facilitator`
+
+Add a new static page and route entry for `/facilitator`.
+
+Purpose:
+
+- explain the offer in merchant language
+- establish proof and trust
+- give merchants two clear next steps
+
+Required page sections:
+
+#### Hero
+
+- headline: hosted x402 facilitator for API sellers
+- subhead: concise explanation that the product helps API operators, AI tools, and MCP sellers monetize endpoints with USDC on Base
+
+#### Primary CTA row
+
+- `View integration docs`
+- `Start onboarding`
+
+For now, onboarding can be a direct email path if there is not yet a self-serve intake flow.
+
+#### Trust strip
+
+Short proof chips that are sourced from existing reality, not aspirational claims:
+
+- live facilitator
+- Base USDC
+- discovery enabled
+- merchant endpoints live
+
+#### Why Satoshi
+
+This should stay specific rather than generic. It should emphasize:
+
+- live seller plus facilitator in production
+- public discovery and status surfaces
+- focus on API and agent-native monetization
+- more hands-on and specific than large generalist providers
+
+#### How it works
+
+Simple three-step explanation:
+
+1. Merchant exposes or prepares paid routes.
+2. Facilitator verifies and settles x402 payments.
+3. Buyers and scanners discover the surface through x402-compatible endpoints.
+
+#### Proof section
+
+Deep-link to live proof surfaces:
+
+- `https://facilitator.bitcoinsapi.com/status`
+- `https://facilitator.bitcoinsapi.com/.well-known/x402`
+- `https://facilitator.bitcoinsapi.com/discovery/resources`
+- `https://bitcoinsapi.com/.well-known/x402`
+- `https://bitcoinsapi.com/openapi.json`
+- `https://bitcoinsapi.com/api/v1/x402-info`
+
+#### Who this is for
+
+Short cards for:
+
+- API companies
+- AI tool vendors
+- MCP sellers
+- developers monetizing premium endpoints
+
+#### Final CTA block
+
+End with one self-education path and one high-intent path:
+
+- `Read docs`
+- `Email api@bitcoinsapi.com for onboarding`
+
+### 2. Strengthen `/x402` as a feeder page
+
+`/x402` should remain the analytics and protocol-proof page, but the top of the page should explicitly acknowledge the merchant use case.
+
+Required change:
+
+- add a short merchant-oriented intro and a strong CTA toward `/facilitator`
+
+This page should not become a second facilitator explainer; it should point toward the dedicated conversion page.
+
+### 3. Add a facilitator callout to `/pricing`
+
+`/pricing` should remain focused on hosted API plans, but it should include a concise facilitator section or callout that says:
+
+- the company also offers hosted x402 facilitation for sellers
+- the right place to learn more is `/facilitator`
+
+This gives existing comparison-oriented traffic a clean handoff without turning the pricing page into mixed-intent content.
+
+### 4. Review shared navigation and footer links
+
+Navigation changes should be conservative:
+
+- add `Facilitator` to the main nav only if it does not crowd the primary product-evaluation path
+- otherwise, link it strongly from `/x402`, `/pricing`, and relevant docs first
+
+Footer, sitemap, canonical tags, and crawl surfaces should all treat `/facilitator` as the canonical merchant page.
+
+## Data and Rendering Model
+
+The facilitator landing page should be mostly static HTML for speed, resilience, and crawlability.
+
+Optional live-proof widgets may fetch from:
+
+- `https://facilitator.bitcoinsapi.com/status`
+- `https://facilitator.bitcoinsapi.com/discovery/resources`
+- `https://bitcoinsapi.com/api/v1/x402-info`
+
+Rules:
+
+- the page must still read well if live fetches fail
+- proof widgets are enhancement, not the page's only evidence
+- live data should be additive and bounded to trust elements, not core comprehension
+
+## Testing Plan
+
+### Routing and regression coverage
+
+- add tests that `/facilitator` is publicly routable
+- add tests that feeder pages include the intended facilitator link(s)
+- add tests for any new redirects, canonical tags, or sitemap entries
+
+### Public HTML assertions
+
+- verify the page contains the primary facilitator CTA(s)
+- verify live proof links point at the intended facilitator and seller endpoints
+- verify the page remains coherent if any client-side proof widget cannot load
+
+### Manual smoke checks
+
+- desktop and mobile review of `/facilitator`
+- confirm the site tree remains understandable when navigating:
+  - home -> x402 -> facilitator
+  - pricing -> facilitator
+  - facilitator -> docs / proof links
+
+### Safety checks
+
+- ensure no static route changes accidentally expose unrelated pages
+- ensure new internal links do not create duplicate-intent page loops between `/x402` and `/facilitator`
+
+## Instrumentation
+
+Track a minimal event set:
+
+- `facilitator_page_view`
+- `facilitator_cta_docs`
+- `facilitator_cta_contact`
+- `x402_to_facilitator_click`
+- `pricing_to_facilitator_click`
+
+The events should retain attribution context sufficient to classify source, for example:
+
+- internal navigation
+- x402 ecosystem referral
+- docs
+- direct
+- GitHub / social
+
+## Expected Outcomes
+
+### Low-variance outcomes
+
+- clearer merchant story
+- stronger internal-link and crawl structure
+- better reviewer confidence because proof and conversion are separated cleanly
+- one canonical page for ecosystem references and outreach
+
+### Medium-variance outcomes
+
+- higher click-through from x402-related traffic into a deliberate merchant path
+- better signal on whether visitors want docs or onboarding help
+
+### High-variance outcomes
+
+- actual merchant adoption and market share, which also depends on external distribution, ecosystem listing status, and outbound efforts
+
+## Risks and Mitigations
+
+### Risk: page cannibalization between `/x402` and `/facilitator`
+
+Mitigation:
+
+- keep `/x402` proof-oriented
+- keep `/facilitator` conversion-oriented
+- avoid duplicating long explainer sections across both pages
+
+### Risk: live widgets become stale or brittle
+
+Mitigation:
+
+- keep the core message static and durable
+- use live widgets only as proof enhancement
+- test the page in a degraded state
+
+### Risk: navigation gets noisier
+
+Mitigation:
+
+- add facilitator links selectively
+- prefer feeder-page handoffs before enlarging the global nav
+
+## Implementation Boundaries
+
+This spec intentionally stops at the merchant funnel. It does not include:
+
+- seller self-serve onboarding flows
+- merchant dashboards
+- settlement export UX
+- deeper facilitator operations tooling
+
+Those should be designed as follow-on sub-projects if the funnel creates real demand.
+
+## Approval Gate
+
+After the written spec is reviewed and approved, the next step is to create a detailed implementation plan before making code changes.


### PR DESCRIPTION
## Summary

- add Raspberry Pi / comparable ARM64 guidance to the self-hosting guide
- document low-storage pruned-node mode versus full `txindex=1` lookup mode
- add a privacy model explaining what self-hosting protects and what it does not
- add local smoke tests for the core self-hosted API path

## Why

This implements the public roadmap work in #19 and strengthens the self-hosting path for users who want Bitcoin fee, mempool, block, transaction, and agent utility without relying on centralized Bitcoin data API logs.

## Validation

- `git diff --check -- docs/self-hosting.md`
- fenced-code-block count is balanced
- verified smoke-test endpoint uses the actual `/api/v1/network` route

Closes #19 when merged.