### PR TITLE
docs: add Raspberry Pi self-hosting guidance

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,21 +1,103 @@
 # Self-Hosting Guide
 
-Deploy the Satoshi API on your own infrastructure with a full Bitcoin Core node.
+Deploy Satoshi API on hardware you control, backed by your own Bitcoin Core node. The goal is to keep fee checks, transaction lookups, address research, and agent requests out of centralized Bitcoin API logs.
 
 ## Prerequisites
 
-- **Bitcoin Core** fully synced with `txindex=1` enabled
+- **Bitcoin Core** synced enough for the mode you choose below
 - **Python 3.10+** (or Docker)
-- **Linux server** (Ubuntu 22.04+ recommended) with 4+ GB RAM
-- A domain name (for Cloudflare Tunnel)
+- **Linux server** or **Raspberry Pi 4/5** with 4+ GB RAM
+- **SSD storage** strongly recommended for Raspberry Pi deployments
+- A domain name if you want public HTTPS through Cloudflare Tunnel
+
+## Deployment Modes
+
+Choose the mode that matches your hardware and privacy needs.
+
+| Mode | Bitcoin Core settings | Best for | Tradeoff |
+| ---- | --------------------- | -------- | -------- |
+| Low-storage Pi mode | `prune=55000`, no `txindex` | Fee intelligence, mempool status, block data, transaction decode/broadcast, local agent access | Full historical transaction and address-history lookups are limited until compact indexing is complete |
+| Full lookup mode | `txindex=1`, no pruning | Arbitrary historical transaction lookups and richer API coverage | Requires much more disk and a longer initial sync |
+
+Do not enable both `prune` and `txindex=1` for the same node. If you start in low-storage mode, you can still use Satoshi API for the highest-value fee and network endpoints while the compact address-indexer roadmap closes the remaining address-history gap.
+
+## Privacy Model
+
+Centralized Bitcoin data APIs can observe sensitive metadata even when they never custody funds:
+
+- which addresses or transactions you research
+- when you check them
+- which IP/network makes the request
+- repeated query patterns that can link wallets, devices, or workflows
+- whether you appear to be preparing to transact during a sensitive window
+
+A self-hosted Satoshi API instance reduces that exposure by keeping Bitcoin data queries on hardware you control. The API talks to your Bitcoin node over local RPC, so address lookups, fee checks, transaction explanations, and agent requests do not need third-party API accounts.
+
+This does not make Bitcoin itself private. Public-chain activity remains public, network-level privacy still depends on your node and wallet setup, and exposing the API publicly can create new logs unless access is restricted. The practical goal is narrower: remove centralized Bitcoin API query logs from your workflow.
+
+## Raspberry Pi Quick Path
+
+Use this path for a Raspberry Pi 4/5 or comparable ARM64 device.
+
+### Hardware target
+
+- Raspberry Pi 4 or 5
+- 4 GB RAM minimum; 8 GB preferred
+- 128 GB+ SSD for low-storage pruned mode; larger is better
+- 1 TB+ SSD if you want full lookup mode with `txindex=1`
+- 64-bit Raspberry Pi OS Lite or Ubuntu Server
+
+### Base packages
+
+```bash
+sudo apt update
+sudo apt install -y python3-venv python3-pip git curl jq ufw
+```
+
+Install and sync Bitcoin Core before starting Satoshi API. For low-storage mode, configure Bitcoin Core with pruning. For full lookup mode, use `txindex=1` and do not prune.
 
 ## 1. Bitcoin Core RPC Configuration
 
 Copy the settings from [`bitcoin-conf-example.conf`](./bitcoin-conf-example.conf) into your `bitcoin.conf` (typically `~/.bitcoin/bitcoin.conf`).
 
+### Low-storage Pi mode
+
+Use this when you want fee intelligence and core Bitcoin data on limited storage:
+
+```ini
+server=1
+prune=55000
+
+rpcuser=satoshiapi
+rpcpassword=CHANGE_ME_TO_A_STRONG_PASSWORD
+
+rpcwhitelist=satoshiapi:getblockchaininfo,getblockcount,getnetworkinfo,getmempoolinfo,estimatesmartfee,getmininginfo,getrawtransaction,gettxout,getmempoolentry,getrawmempool,getblockstats,getchaintips,decoderawtransaction,sendrawtransaction,getblocktemplate,getblockhash,getblock,getblockheader,validateaddress,gettxoutsetinfo,gettxoutproof
+
+rpcbind=127.0.0.1
+rpcallowip=127.0.0.1
+```
+
+### Full lookup mode
+
+Use this when you need arbitrary historical transaction lookup support:
+
+```ini
+server=1
+txindex=1
+
+rpcuser=satoshiapi
+rpcpassword=CHANGE_ME_TO_A_STRONG_PASSWORD
+
+rpcwhitelist=satoshiapi:getblockchaininfo,getblockcount,getnetworkinfo,getmempoolinfo,estimatesmartfee,getmininginfo,getrawtransaction,gettxout,getmempoolentry,getrawmempool,getblockstats,getchaintips,decoderawtransaction,sendrawtransaction,getblocktemplate,getblockhash,getblock,getblockheader,validateaddress,gettxoutsetinfo,gettxoutproof
+
+rpcbind=127.0.0.1
+rpcallowip=127.0.0.1
+```
+
 Key points:
 - **Change the password** in `rpcpassword` to a strong random value
-- `txindex=1` is required for transaction lookup endpoints -- if you're enabling this on an existing node, you'll need to reindex (`bitcoind -reindex`)
+- `txindex=1` is required for arbitrary historical transaction lookup endpoints
+- if you enable `txindex=1` on an existing node, you need to reindex (`bitcoind -reindex`)
 - The `rpcwhitelist` restricts the API user to only the commands the API actually needs
 - `rpcbind=127.0.0.1` ensures RPC is never exposed to the network
 
@@ -66,6 +148,21 @@ satoshi-api
 # or: bitcoin-api (both commands work)
 # -> http://localhost:9332/docs
 ```
+
+For Raspberry Pi low-storage mode, you can start with a minimal environment:
+
+```bash
+export BITCOIN_RPC_HOST=127.0.0.1
+export BITCOIN_RPC_PORT=8332
+export BITCOIN_RPC_USER=satoshiapi
+export BITCOIN_RPC_PASSWORD=YOUR_PASSWORD
+export API_HOST=127.0.0.1
+export API_PORT=9332
+
+satoshi-api
+```
+
+Keep `API_HOST=127.0.0.1` if the API is only for your own machine, Tailscale network, or Cloudflare Tunnel. Binding to all interfaces is only appropriate when you understand the network exposure.
 
 **Optional extras** -- install only what you need:
 
@@ -138,6 +235,23 @@ sudo systemctl start cloudflared
 The API can optionally integrate with Upstash Redis (persistent rate limiting), Resend (transactional email), and PostHog (landing page analytics). **All default to disabled and are not required for self-hosting.** In-memory rate limiting works fine for single-instance deployments. See `.env.production.example` for configuration details.
 
 ## 6. Monitoring
+
+### Smoke tests
+
+Run these locally after startup:
+
+```bash
+curl http://localhost:9332/api/v1/health | jq
+curl http://localhost:9332/api/v1/fees/recommended | jq
+curl http://localhost:9332/api/v1/fees/landscape | jq
+curl http://localhost:9332/api/v1/network | jq
+```
+
+If a transaction or address-history endpoint fails on a pruned node, first check whether that endpoint needs historical data unavailable in low-storage mode. The expected path is:
+
+- low-storage mode today for fee, mempool, block, network, and agent utility
+- full lookup mode when you need `txindex=1`
+- compact address indexing as the roadmap item that removes the remaining storage barrier
 
 ### UptimeRobot
 


### PR DESCRIPTION
## Summary

- add Raspberry Pi / comparable ARM64 guidance to the self-hosting guide
- document low-storage pruned-node mode versus full `txindex=1` lookup mode
- add a privacy model explaining what self-hosting protects and what it does not
- add local smoke tests for the core self-hosted API path

## Why

This implements the public roadmap work in #19 and strengthens the self-hosting path for users who want Bitcoin fee, mempool, block, transaction, and agent utility without relying on centralized Bitcoin data API logs.

## Validation

- `git diff --check origin/master..HEAD -- docs/self-hosting.md`
- fenced-code-block count is balanced
- verified smoke-test endpoint uses the actual `/api/v1/network` route

Closes #19 when merged.