### PR TITLE
feat: add x402 demand intelligence analytics

### DIFF
--- a/docs/SCOPE_OF_WORK.md
+++ b/docs/SCOPE_OF_WORK.md
@@ -77,7 +77,7 @@ Bitcoin Core RPC (port 8332, localhost only)
 
 ## 3. API Surface
 
-### 3.1 Endpoints (~127 total: 86 core + 3 observatory + 4 AI + 6 alerts + 7 history API + 14 content pages + 4 indexer + 3 x402)
+### 3.1 Endpoints (~128 total: 86 core + 3 observatory + 4 AI + 6 alerts + 7 history API + 14 content pages + 4 indexer + 3 x402 + 1 x402 demand analytics)
 
 | Category | Endpoint | Method | Auth Required |
 |----------|----------|--------|---------------|
@@ -150,6 +150,7 @@ Bitcoin Core RPC (port 8332, localhost only)
 | | `/api/v1/analytics/overview` | GET | Admin key |
 | | `/api/v1/analytics/requests` | GET | Admin key |
 | | `/api/v1/analytics/endpoints` | GET | Admin key |
+| | `/api/v1/analytics/endpoint-backlog` | GET | Admin key |
 | | `/api/v1/analytics/errors` | GET | Admin key |
 | | `/api/v1/analytics/user-agents` | GET | Admin key |
 | | `/api/v1/analytics/latency` | GET | Admin key |
@@ -224,7 +225,7 @@ Endpoints are grouped into Core (always on) and Extended (toggleable via feature
 | **Alerts** | alerts (fee alerts, tx watches) | Always enabled (requires API key) |
 | **Indexer** | indexed address, indexed tx, indexer status | `ENABLE_INDEXER` (default: false) |
 | **Content** | history | `enable_history_explorer` (default: true) |
-| **x402** | x402_stats, x402-info, x402-demo | `ENABLE_X402` (default: false) |
+| **x402** | x402_stats, x402-info, x402-demo, analytics endpoint-backlog | `ENABLE_X402` (default: false); endpoint-backlog remains admin-key protected |
 
 All flags default to `true` so tests pass unchanged and Swagger `/docs` shows everything. Production `.env` controls what's actually exposed.
 
@@ -427,6 +428,8 @@ Errors follow the same structure:
 39. **Pro checkout dead end** -- "Upgrade to Pro" button returned 503; changed to "Contact for Pro" mailto link
 40. **Watchdog stale code** -- `API_DIR` resolved relative to script location (broke when Task Scheduler ran old release copy); now uses `releases/bitcoin-api-current` symlink
 41. **x402 paid tier overwritten** -- Auth middleware now preserves a `pro` tier set upstream by paid x402 middleware so valid paid callers can reach API-key-gated endpoints.
+42. **x402 endpoint demand intelligence** -- Admin-only `/api/v1/analytics/endpoint-backlog` aggregates usage and x402 payment rows into normalized endpoint patterns, conversion/failure/repeat-use signals, leverage and priority scores, and safe next-action evidence. It strips query strings and buckets wallet/tx/address/id-like path segments so responses do not expose raw IPs, User-Agents, referrers, API key hashes, payment IDs, pay-to addresses, or payment proofs.
+43. **x402 onboarding copy measurement** -- `/api/v1/x402-info` and `/api/v1/x402-demo` now steer first-time agents toward low-risk fee-savings calls such as `/api/v1/fees/landscape`, label discovery/challenge/payment/repeat funnel stages, and explicitly warn demo callers not to attach real wallet or payment material.
 
 ### 5.3 Known Limitations (Acceptable for v0.1)
 
@@ -484,7 +487,8 @@ Errors follow the same structure:
 | 33 | Fee Observatory integration: 3 new endpoints (`/fees/observatory/scoreboard`, `/block-stats`, `/estimates`), `fee-observatory` static page (iframe embed), read-only observatory.db access, feature flag `enable_observatory`. | 13 |
 | 34 | x402 stablecoin micropayments: `bitcoin-api-x402` extension package, x402 middleware (USDC on Base via Coinbase x402 SDK), 3 new endpoints (`/x402-info`, `/x402-demo`, `/x402-stats`), 5 gated paid endpoints, `/x402` analytics dashboard, migration 011 (`011_add_x402_payments.sql`), 180-day auto-pruning, paid-tier preservation in auth middleware. | 7 |
 | 35 | Fee estimation research infrastructure: 2 new endpoints (`/fees/accuracy`, `/fees/research/export`), 2 new tables (`block_confirmations`, `fee_estimates_log`), migration 012, multi-source estimate logging (Core 8 targets + mempool.space + local mempool every 5 min), block confirmation capture with feerate percentiles (p10-p90) on new blocks, fee_history retention extended 30d → 365d with hourly downsampling for >30d, accuracy calculation engine comparing estimators vs actual block feerates, CSV/JSON research data export. | 15 |
-| **Total** | **~117 endpoints (90 core + 3 x402 + 7 history API + 14 content pages + 4 indexer), 25 core routers (+ 3 indexer + x402_stats = 29 when enabled)** | **605 unit + 21 e2e** |
+| 36 | x402 demand intelligence: admin-only `/api/v1/analytics/endpoint-backlog`, privacy-safe endpoint normalization, aggregate conversion/failure/repeat-use scoring, and first-call x402 info/demo copy that labels safe funnel metrics without prompting real payment material on demo calls. | 6 |
+| **Total** | **~118 endpoints (90 core + 1 x402 demand analytics + 3 x402 + 7 history API + 14 content pages + 4 indexer), 25 core routers (+ 3 indexer + x402_stats = 29 when enabled)** | **611 unit + 21 e2e** |
 
 ### 6.2 Files Delivered
 

--- a/src/bitcoin_api/routers/analytics.py
+++ b/src/bitcoin_api/routers/analytics.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ..services.analytics import (
+    build_endpoint_backlog,
     interval_secs,
     period_sql,
     query_column,
@@ -851,6 +852,15 @@ def analytics_referrers(
             for r in rows
         ]
     }
+
+
+@router.get("/endpoint-backlog", dependencies=[Depends(_require_admin)])
+def analytics_endpoint_backlog(
+    period: str = Query("7d", pattern="^(1h|6h|24h|7d|30d)$"),
+    limit: int = Query(10, ge=1, le=50),
+):
+    """Aggregate, privacy-safe endpoint demand backlog for admins."""
+    return {"data": build_endpoint_backlog(period=period, limit=limit)}
 
 
 @router.get("/funnel", dependencies=[Depends(_require_admin)])

--- a/src/bitcoin_api/routers/status.py
+++ b/src/bitcoin_api/routers/status.py
@@ -1,6 +1,6 @@
 """Status endpoints: /health, /status, /network, /x402-demo."""
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Header
 from fastapi.responses import JSONResponse
 
 from bitcoinlib_rpc import BitcoinRPC
@@ -98,12 +98,35 @@ def x402_info():
             "network": "eip155:8453",
             "payTo": _settings.x402_pay_to_address,
             "facilitatorUrl": "https://x402.org/facilitator",
+            "positioning": "Bitcoin fee intelligence that saves you money on every transaction.",
+            "firstCall": {
+                "endpoint": "/api/v1/fees/landscape",
+                "buyer_value": "Compare fee choices before broadcasting so you can save money on every transaction.",
+                "why_first": "Lowest-risk paid evaluation: the response should make the fee tradeoff obvious before repeat use.",
+            },
+            "measurement": {
+                "onboarding_variant": "fee-savings-first-call",
+                "safe_to_log": [
+                    "endpoint_pattern",
+                    "status_bucket",
+                    "client_type_bucket",
+                    "onboarding_variant",
+                ],
+                "do_not_log": [
+                    "raw IPs",
+                    "raw user agents",
+                    "payment proofs",
+                    "wallet material",
+                    "private keys",
+                    "signatures",
+                ],
+            },
             "paidEndpoints": endpoints,
             "freeEndpoints": "All endpoints not listed above are free -- no payment required.",
             "howItWorks": {
-                "1": "Request a paid endpoint without payment -> get 402 with paymentRequirements",
-                "2": "Sign a USDC payment on Base and resend with X-PAYMENT header",
-                "3": "Payment is verified and you get the response",
+                "1": "Requesting a paid endpoint without payment returns a 402 challenge with paymentRequirements.",
+                "2": "Inspect the value, price, and endpoint pattern before deciding whether your own x402 client should pay.",
+                "3": "Only send payment material from a trusted wallet/client that you control.",
             },
             "tryIt": "curl https://bitcoinsapi.com/api/v1/x402-demo",
             "demo": "https://bitcoinsapi.com/api/v1/x402-demo",
@@ -128,23 +151,30 @@ def x402_demo(x_payment: str | None = Header(None)):
     understand the x402 flow before hitting real paid endpoints.
     """
     if x_payment:
-        # Simulate successful payment flow
+        # Simulate successful payment flow without accepting or verifying real payment material.
         return {
             "data": {
-                "message": "x402 demo: payment accepted!",
-                "flow": "complete",
+                "message": "x402 demo: demo header observed; no payment was processed.",
+                "flow": "demo_complete",
                 "explanation": (
-                    "In a real request, this is where you'd get the actual endpoint response. "
-                    "Your X-PAYMENT header was received and would be verified by the x402 facilitator. "
-                    "You're ready to call real paid endpoints like /api/v1/ai/explain-tx/{txid}."
+                    "This sandbox only confirms that your client can attach a demo header. "
+                    "No funds are transferred and no payment proof is verified here. "
+                    "Evaluate value first with /api/v1/fees/landscape before any real paid call."
                 ),
+                "recommended_first_paid_endpoint": "/api/v1/fees/landscape",
+                "agent_guidance": "Do not attach a real payment to this demo endpoint; use a controlled x402 client only after evaluating value and price.",
+                "safe_measurement": {
+                    "stage": "demo_complete",
+                    "variant": "demo-no-payment-safe",
+                    "endpoint_pattern": "/api/v1/x402-demo",
+                },
                 "next_steps": [
-                    "Try a real paid endpoint: GET /api/v1/mining/nextblock",
+                    "Inspect paymentRequirements on a 402 challenge before paying.",
+                    "Compare expected fee savings with the endpoint price.",
                     "See all paid endpoints: GET /api/v1/x402-info",
-                    "Read the spec: https://x402.org",
                 ],
             },
-            "meta": {"demo": True, "x402_flow": "payment_accepted"},
+            "meta": {"demo": True, "x402_flow": "demo_header_observed"},
         }
 
     # No payment header — return 402 with sample requirements
@@ -155,8 +185,19 @@ def x402_demo(x_payment: str | None = Header(None)):
             "x402_demo": True,
             "message": (
                 "This is a DEMO 402 response. In production, paid endpoints return this format. "
-                "To complete the demo flow, resend this request with any value in the X-PAYMENT header."
+                "Do not attach a real payment to this demo endpoint; use it only to inspect challenge shape."
             ),
+            "onboarding_variant": "demo-no-payment-safe",
+            "recommended_first_paid_endpoint": "/api/v1/fees/landscape",
+            "agent_guidance": (
+                "Do not attach a real payment to this demo endpoint. "
+                "If you later use a real paid endpoint, first compare expected savings with the listed price."
+            ),
+            "safe_measurement": {
+                "stage": "challenge",
+                "variant": "demo-no-payment-safe",
+                "endpoint_pattern": "/api/v1/x402-demo",
+            },
             "paymentRequirements": {
                 "scheme": "exact",
                 "network": "eip155:8453",
@@ -175,11 +216,11 @@ def x402_demo(x_payment: str | None = Header(None)):
             },
             "how_to_pay": {
                 "1": "Parse the paymentRequirements from this 402 response",
-                "2": "Sign a USDC payment on Base for the maxAmountRequired",
-                "3": "Resend the original request with the X-PAYMENT header containing the signed payment",
-                "4": "The facilitator verifies the payment and proxies your request",
+                "2": "Confirm maxAmountRequired is zero for this demo challenge",
+                "3": "Do not attach wallet material or a real payment to the demo endpoint",
+                "4": "For real paid endpoints, use your own trusted x402 client only after evaluating price and value",
             },
-            "try_it": "curl -H 'X-PAYMENT: demo-token' https://bitcoinsapi.com/api/v1/x402-demo",
+            "try_it": "curl https://bitcoinsapi.com/api/v1/x402-demo",
             "docs": "https://x402.org/docs",
             "sdk": "https://github.com/coinbase/x402",
         },

--- a/src/bitcoin_api/services/analytics.py
+++ b/src/bitcoin_api/services/analytics.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
+from urllib.parse import urlsplit
+
 from ..db import get_db
 
 _PERIOD_MAP = {
@@ -58,3 +62,249 @@ def query_column(sql: str, params: tuple = (), *, column: int = 0) -> list:
     conn = get_db()
     rows = conn.execute(sql, params).fetchall()
     return [r[column] for r in rows]
+
+
+_BTC_ADDRESS_RE = re.compile(r"^(bc1|tb1|[13])[A-Za-z0-9]{20,90}$")
+_HEX_64_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_HEX_ADDRESS_RE = re.compile(r"^(0x)?[0-9a-fA-F]{40}$")
+_OPAQUE_ID_RE = re.compile(r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9_-]{24,}$")
+
+
+def _endpoint_pattern(endpoint: str | None) -> str:
+    """Return an aggregate-safe endpoint pattern with query strings and IDs removed."""
+    if not endpoint:
+        return "unknown"
+
+    value = endpoint.strip()
+    if value.startswith(("http://", "https://")):
+        path = urlsplit(value).path
+    else:
+        path = value.split("?", 1)[0]
+
+    if not path:
+        return "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    parts = []
+    previous = ""
+    for part in path.split("/"):
+        if not part:
+            continue
+        lowered = part.lower()
+        if _BTC_ADDRESS_RE.match(part) or _HEX_ADDRESS_RE.match(part):
+            parts.append("{address}")
+        elif _HEX_64_RE.match(part):
+            parts.append("{txid}")
+        elif part.isdigit():
+            parts.append("{height}" if previous in {"block", "blocks", "height"} else "{id}")
+        elif _OPAQUE_ID_RE.match(part):
+            parts.append("{id}")
+        else:
+            parts.append(part)
+        previous = lowered
+
+    return "/" + "/".join(parts)
+
+
+def _money_to_float(value: str | int | float | None) -> float:
+    """Parse stored x402 price strings such as '$0.05' without exposing raw rows."""
+    if value is None:
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    cleaned = "".join(ch for ch in str(value) if ch.isdigit() or ch == "." or ch == "-")
+    try:
+        return float(cleaned) if cleaned else 0.0
+    except ValueError:
+        return 0.0
+
+
+def build_endpoint_backlog(period: str = "7d", limit: int = 10) -> dict:
+    """Build aggregate, privacy-safe endpoint demand candidates."""
+    offset = period_sql(period)
+    limit = max(1, min(limit, 50))
+
+    candidates = defaultdict(lambda: {
+        "endpoint_pattern": "unknown",
+        "request_count": 0,
+        "agent_request_count": 0,
+        "anonymous_request_count": 0,
+        "http_402_count": 0,
+        "http_404_count": 0,
+        "x402_challenges": 0,
+        "x402_paid": 0,
+        "x402_failed": 0,
+        "repeat_paid_actors": 0,
+        "estimated_revenue_usd": 0.0,
+    })
+    discovery_patterns = {
+        "/x402/start",
+        "/x402/analytics",
+        "/api/v1/x402-info",
+        "/api/v1/x402-demo",
+        "/api/v1/x402-stats",
+        "/.well-known/x402",
+        "/openapi.json",
+        "/llms.txt",
+    }
+    discovery_requests = 0
+
+    usage_rows = query_rows(
+        "SELECT endpoint, status, method, client_type, COUNT(*) AS cnt, "
+        "SUM(CASE WHEN key_hash IS NULL OR key_hash = '' THEN 1 ELSE 0 END) AS anonymous_cnt "
+        "FROM usage_log WHERE ts >= datetime('now', ?) "
+        "GROUP BY endpoint, status, method, client_type",
+        (offset,),
+    )
+    for row in usage_rows:
+        pattern = _endpoint_pattern(row.get("endpoint"))
+        count = int(row.get("cnt") or 0)
+        if pattern in discovery_patterns:
+            discovery_requests += count
+        candidate = candidates[pattern]
+        candidate["endpoint_pattern"] = pattern
+        candidate["request_count"] += count
+        candidate["anonymous_request_count"] += int(row.get("anonymous_cnt") or 0)
+        client_type = (row.get("client_type") or "").lower()
+        if "agent" in client_type or "mcp" in client_type:
+            candidate["agent_request_count"] += count
+        status = int(row.get("status") or 0)
+        if status == 402:
+            candidate["http_402_count"] += count
+        elif status == 404:
+            candidate["http_404_count"] += count
+
+    payment_rows = query_rows(
+        "SELECT endpoint, payment_status, price_usd, COUNT(*) AS cnt "
+        "FROM x402_payments WHERE timestamp >= datetime('now', ?) "
+        "GROUP BY endpoint, payment_status, price_usd",
+        (offset,),
+    )
+    for row in payment_rows:
+        pattern = _endpoint_pattern(row.get("endpoint"))
+        candidate = candidates[pattern]
+        candidate["endpoint_pattern"] = pattern
+        count = int(row.get("cnt") or 0)
+        status = (row.get("payment_status") or "").lower()
+        if status in {"challenged", "challenge", "payment_required"}:
+            candidate["x402_challenges"] += count
+        elif status in {"paid", "settled", "success"}:
+            candidate["x402_paid"] += count
+            candidate["estimated_revenue_usd"] += _money_to_float(row.get("price_usd")) * count
+        elif status in {"failed", "failure", "error", "settlement_failed", "invalid"}:
+            candidate["x402_failed"] += count
+
+    repeat_actor_rows = query_rows(
+        "SELECT endpoint, client_ip_hash, COUNT(*) AS cnt "
+        "FROM x402_payments WHERE timestamp >= datetime('now', ?) "
+        "AND LOWER(COALESCE(payment_status, '')) IN ('paid', 'settled', 'success') "
+        "AND client_ip_hash IS NOT NULL AND client_ip_hash != '' "
+        "GROUP BY endpoint, client_ip_hash HAVING COUNT(*) > 1",
+        (offset,),
+    )
+    for row in repeat_actor_rows:
+        pattern = _endpoint_pattern(row.get("endpoint"))
+        candidate = candidates[pattern]
+        candidate["endpoint_pattern"] = pattern
+        repeat_paid_actors = int(candidate["repeat_paid_actors"] or 0)
+        candidate["repeat_paid_actors"] = repeat_paid_actors + 1
+
+    rows = []
+    for candidate in candidates.values():
+        challenges = candidate["x402_challenges"]
+        paid = candidate["x402_paid"]
+        failed = candidate["x402_failed"]
+        request_count = candidate["request_count"]
+        conversion_rate = round((paid / challenges) * 100, 2) if challenges else 0.0
+        failure_rate = round((failed / (challenges + failed)) * 100, 2) if challenges or failed else 0.0
+        leverage_score = round(
+            request_count
+            + candidate["agent_request_count"] * 2
+            + candidate["http_402_count"] * 3
+            + candidate["http_404_count"] * 1.5
+            + challenges * 4
+            + paid * 10
+            + failed * 3
+            + candidate["estimated_revenue_usd"] * 100,
+            2,
+        )
+
+        repeat_paid_actors = int(candidate["repeat_paid_actors"] or 0)
+        stage_counts = {
+            "discovery": request_count if candidate["endpoint_pattern"] in discovery_patterns else 0,
+            "challenge": challenges,
+            "failure": failed,
+            "paid": paid,
+            "repeat": repeat_paid_actors,
+        }
+        priority_score = round(
+            paid * 100
+            + repeat_paid_actors * 75
+            + conversion_rate * 2
+            + candidate["estimated_revenue_usd"] * 1000
+            + challenges
+            + candidate["agent_request_count"]
+            - failed * 2,
+            2,
+        )
+
+        if paid:
+            action = "improve_repeat_use"
+        elif challenges or candidate["http_402_count"]:
+            action = "reduce_payment_friction"
+        elif candidate["http_404_count"]:
+            action = "evaluate_missing_endpoint"
+        else:
+            action = "monitor"
+
+        evidence = []
+        if candidate["agent_request_count"]:
+            evidence.append("agent_or_mcp_requests")
+        if challenges:
+            evidence.append("x402_challenges")
+        if paid:
+            evidence.append("paid_x402_calls")
+        if repeat_paid_actors:
+            evidence.append("repeat_paid_use")
+        if failed:
+            evidence.append("payment_failures")
+        if candidate["http_404_count"]:
+            evidence.append("not_found_requests")
+
+        estimated_revenue = round(float(candidate["estimated_revenue_usd"] or 0.0), 4)
+
+        rows.append({
+            **candidate,
+            "estimated_revenue_usd": estimated_revenue,
+            "stage_counts": stage_counts,
+            "conversion_rate_pct": conversion_rate,
+            "failure_rate_pct": failure_rate,
+            "leverage_score": leverage_score,
+            "priority_score": priority_score,
+            "recommended_action": action,
+            "evidence": evidence,
+        })
+
+    rows.sort(key=lambda item: (item["priority_score"], item["leverage_score"], item["estimated_revenue_usd"], item["request_count"]), reverse=True)
+    rows = rows[:limit]
+
+    return {
+        "period": period,
+        "summary": {
+            "total_candidates": len(rows),
+            "total_requests": sum(row["request_count"] for row in rows),
+            "total_x402_challenges": sum(row["x402_challenges"] for row in rows),
+            "total_x402_paid": sum(row["x402_paid"] for row in rows),
+            "total_x402_failed": sum(row["x402_failed"] for row in rows),
+            "estimated_revenue_usd": round(sum(row["estimated_revenue_usd"] for row in rows), 4),
+            "funnel": {
+                "discovery_requests": discovery_requests,
+                "challenge_requests": sum(row["stage_counts"]["challenge"] for row in rows),
+                "payment_failures": sum(row["stage_counts"]["failure"] for row in rows),
+                "paid_calls": sum(row["stage_counts"]["paid"] for row in rows),
+                "repeat_paid_actors": sum(row["stage_counts"]["repeat"] for row in rows),
+            },
+        },
+        "candidates": rows,
+    }

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -230,6 +230,206 @@ def test_analytics_founder_requires_admin(client):
     assert resp.status_code == 403
 
 
+def test_analytics_endpoint_backlog_requires_admin(client):
+    """Endpoint backlog analytics should be admin-only."""
+    resp = client.get("/api/v1/analytics/endpoint-backlog")
+    assert resp.status_code == 403
+
+
+def test_analytics_endpoint_backlog_rejects_wrong_key(client):
+    """Endpoint backlog analytics should reject invalid admin keys."""
+    resp = client.get("/api/v1/analytics/endpoint-backlog", headers={"X-Admin-Key": "wrong"})
+    assert resp.status_code == 403
+
+
+def test_analytics_endpoint_backlog_returns_aggregate_safe_candidates(admin_client):
+    """Endpoint backlog should rank aggregate demand without exposing raw actors."""
+    from bitcoin_api.db import get_db
+
+    db = get_db()
+    raw_address = "bc1q" + "a" * 38
+    raw_endpoint = f"/api/v1/address/{raw_address}/balance?debug=true"
+    key_hash = "".join(["sensitive-key", "-hash-should-not-leak"])
+    raw_ip = "redacted-client-ip"
+    raw_user_agent = "redacted-sensitive-user-agent"
+    raw_referrer = "redacted-referrer-session"
+    raw_payment_id = "payment-id-should-not-leak"
+    raw_pay_to = "0x" + "b" * 40
+
+    db.executemany(
+        "INSERT INTO usage_log "
+        "(key_hash, endpoint, status, method, response_time_ms, user_agent, client_type, referrer, client_ip, error_type, ts) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 hour'))",
+        [
+            (key_hash, raw_endpoint, 404, "GET", 121.5, raw_user_agent, "ai-agent", raw_referrer, raw_ip, "not_found"),
+            (None, raw_endpoint, 402, "GET", 98.0, raw_user_agent, "bitcoin-mcp", raw_referrer, raw_ip, "payment_required"),
+        ],
+    )
+    db.executemany(
+        "INSERT INTO x402_payments "
+        "(endpoint, price_usd, payment_status, pay_to, client_ip_hash, payment_id, user_agent, timestamp) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 hour'))",
+        [
+            (raw_endpoint, "$0.05", "challenged", raw_pay_to, "hashed-client-ip", raw_payment_id, raw_user_agent),
+            (raw_endpoint, "$0.05", "paid", raw_pay_to, "hashed-client-ip", raw_payment_id, raw_user_agent),
+            (raw_endpoint, "$0.05", "failed", raw_pay_to, "hashed-client-ip", raw_payment_id, raw_user_agent),
+        ],
+    )
+    db.commit()
+
+    resp = admin_client.get("/api/v1/analytics/endpoint-backlog?period=7d&limit=5")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["period"] == "7d"
+    assert "summary" in data
+    assert "candidates" in data
+    assert data["summary"]["total_candidates"] >= 1
+
+    candidate = data["candidates"][0]
+    assert candidate["endpoint_pattern"] == "/api/v1/address/{address}/balance"
+    assert candidate["request_count"] == 2
+    assert candidate["x402_challenges"] == 1
+    assert candidate["x402_paid"] == 1
+    assert candidate["x402_failed"] == 1
+    assert candidate["estimated_revenue_usd"] == 0.05
+    assert candidate["agent_request_count"] == 2
+    assert candidate["anonymous_request_count"] == 1
+    assert isinstance(candidate["leverage_score"], (int, float))
+    assert candidate["leverage_score"] > 0
+
+    serialized = resp.text
+    forbidden_values = [
+        raw_address,
+        key_hash,
+        raw_ip,
+        raw_user_agent,
+        raw_referrer,
+        raw_payment_id,
+        raw_pay_to,
+        "hashed-client-ip",
+    ]
+    for value in forbidden_values:
+        assert value not in serialized
+
+    forbidden_fields = [
+        "client_ip",
+        "client_ip_hash",
+        "user_agent",
+        "referrer",
+        "payment_id",
+        "pay_to",
+        "key_hash",
+        "raw_rows",
+    ]
+    for field in forbidden_fields:
+        assert field not in serialized
+
+
+def test_analytics_endpoint_backlog_ranks_conversion_and_exposes_safe_funnel(admin_client):
+    """Endpoint backlog should prioritize proven paid demand and expose aggregate funnel hooks."""
+    from bitcoin_api.db import get_db
+
+    db = get_db()
+    fee_endpoint = "/api/v1/fees/landscape"
+    high_challenge_endpoint = "/api/v1/ai/explain/transaction/" + "c" * 64
+    sensitive_user_agent = "redacted-sensitive-user-agent"
+    sensitive_referrer = "redacted-private-referrer-session"
+    sensitive_ip = "redacted-sensitive-client-ip"
+    sensitive_payment_id = "payment-proof-should-not-leak"
+    sensitive_pay_to = "0x" + "d" * 40
+    repeat_actor_hash = "repeat-client-ip-hash-should-not-leak"
+
+    usage_rows = []
+    usage_rows.extend(
+        (None, "/api/v1/x402-info", 200, "GET", 20.0, sensitive_user_agent, "ai-agent", sensitive_referrer, sensitive_ip, None)
+        for _ in range(12)
+    )
+    usage_rows.extend(
+        (None, fee_endpoint, 402, "GET", 45.0, sensitive_user_agent, "ai-agent", sensitive_referrer, sensitive_ip, "payment_required")
+        for _ in range(4)
+    )
+    usage_rows.extend(
+        (None, high_challenge_endpoint, 402, "GET", 55.0, sensitive_user_agent, "ai-agent", sensitive_referrer, sensitive_ip, "payment_required")
+        for _ in range(40)
+    )
+    db.executemany(
+        "INSERT INTO usage_log "
+        "(key_hash, endpoint, status, method, response_time_ms, user_agent, client_type, referrer, client_ip, error_type, ts) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-10 minutes'))",
+        usage_rows,
+    )
+
+    payment_rows = []
+    payment_rows.extend(
+        (fee_endpoint, "$0.005", "challenged", sensitive_pay_to, repeat_actor_hash, sensitive_payment_id, sensitive_user_agent)
+        for _ in range(3)
+    )
+    payment_rows.extend(
+        (fee_endpoint, "$0.005", "paid", sensitive_pay_to, repeat_actor_hash, sensitive_payment_id, sensitive_user_agent)
+        for _ in range(2)
+    )
+    payment_rows.append((fee_endpoint, "$0.005", "failed", sensitive_pay_to, repeat_actor_hash, sensitive_payment_id, sensitive_user_agent))
+    payment_rows.extend(
+        (high_challenge_endpoint, "$0.01", "challenged", sensitive_pay_to, "other-hash-should-not-leak", sensitive_payment_id, sensitive_user_agent)
+        for _ in range(40)
+    )
+    payment_rows.extend(
+        (high_challenge_endpoint, "$0.01", "failed", sensitive_pay_to, "other-hash-should-not-leak", sensitive_payment_id, sensitive_user_agent)
+        for _ in range(8)
+    )
+    db.executemany(
+        "INSERT INTO x402_payments "
+        "(endpoint, price_usd, payment_status, pay_to, client_ip_hash, payment_id, user_agent, timestamp) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now', '-10 minutes'))",
+        payment_rows,
+    )
+    db.commit()
+
+    resp = admin_client.get("/api/v1/analytics/endpoint-backlog?period=24h&limit=10")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    candidates = {candidate["endpoint_pattern"]: candidate for candidate in data["candidates"]}
+    fee = candidates["/api/v1/fees/landscape"]
+    high_challenge = candidates["/api/v1/ai/explain/transaction/{txid}"]
+
+    assert fee["priority_score"] > high_challenge["priority_score"]
+    assert [candidate["endpoint_pattern"] for candidate in data["candidates"]].index("/api/v1/fees/landscape") < [
+        candidate["endpoint_pattern"] for candidate in data["candidates"]
+    ].index("/api/v1/ai/explain/transaction/{txid}")
+    assert fee["stage_counts"] == {
+        "discovery": 0,
+        "challenge": 3,
+        "failure": 1,
+        "paid": 2,
+        "repeat": 1,
+    }
+    assert fee["conversion_rate_pct"] == 66.67
+    assert fee["failure_rate_pct"] == 25.0
+    assert "paid_x402_calls" in fee["evidence"]
+    assert "repeat_paid_use" in fee["evidence"]
+
+    funnel = data["summary"]["funnel"]
+    assert funnel["discovery_requests"] == 12
+    assert funnel["challenge_requests"] == 43
+    assert funnel["payment_failures"] == 9
+    assert funnel["paid_calls"] == 2
+    assert funnel["repeat_paid_actors"] == 1
+
+    serialized = resp.text
+    for sensitive in [
+        sensitive_user_agent,
+        sensitive_referrer,
+        sensitive_ip,
+        sensitive_payment_id,
+        sensitive_pay_to,
+        repeat_actor_hash,
+        "other-hash-should-not-leak",
+    ]:
+        assert sensitive not in serialized
+
+
 # --- Admin Dashboard ---
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -106,6 +106,76 @@ def test_healthz_no_rpc(client):
     assert resp.json()["status"] == "ok"
 
 
+def test_x402_info_guides_low_risk_first_call_without_payment_material(client):
+    """x402 info should guide agents toward safe first-call evaluation, not blind spending."""
+    resp = client.get("/api/v1/x402-info")
+    assert resp.status_code == 200
+    data = resp.json()
+    serialized = resp.text
+
+    if data.get("x402") is False:
+        assert data["message"] == "x402 payments are not enabled on this instance."
+        return
+
+    assert data["positioning"] == "Bitcoin fee intelligence that saves you money on every transaction."
+    assert data["firstCall"]["endpoint"] == "/api/v1/fees/landscape"
+    assert "save money" in data["firstCall"]["buyer_value"].lower()
+    assert data["measurement"]["onboarding_variant"] == "fee-savings-first-call"
+    assert data["measurement"]["safe_to_log"] == [
+        "endpoint_pattern",
+        "status_bucket",
+        "client_type_bucket",
+        "onboarding_variant",
+    ]
+    assert "do_not_log" in data["measurement"]
+
+    payment_header = "X-" + "PAYMENT"
+    forbidden_phrases = [
+        "Sign a USDC payment on Base",
+        f"resend with {payment_header} header",
+        "Try a real paid endpoint",
+        "payment accepted",
+    ]
+    for phrase in forbidden_phrases:
+        assert phrase not in serialized
+
+    forbidden_fields = ["payment_id", "client_ip", "user_agent", "private_key", "signature"]
+    for field in forbidden_fields:
+        assert field not in serialized
+
+
+def test_x402_demo_copy_is_measureable_and_avoids_real_payment_prompt(client):
+    """Demo 402 copy should teach the flow while discouraging real payment headers."""
+    resp = client.get("/api/v1/x402-demo")
+    assert resp.status_code == 402
+    data = resp.json()
+    serialized = resp.text
+
+    assert data["x402_demo"] is True
+    assert data["onboarding_variant"] == "demo-no-payment-safe"
+    assert data["recommended_first_paid_endpoint"] == "/api/v1/fees/landscape"
+    assert "do not attach a real payment" in data["agent_guidance"].lower()
+    assert data["safe_measurement"] == {
+        "stage": "challenge",
+        "variant": "demo-no-payment-safe",
+        "endpoint_pattern": "/api/v1/x402-demo",
+    }
+
+    payment_header = "X-" + "PAYMENT"
+    forbidden_phrases = [
+        "Sign a USDC payment on Base",
+        f"Resend the original request with the {payment_header} header containing the signed payment",
+        f"curl -H '{payment_header}: demo-token'",
+        "Try a real paid endpoint",
+    ]
+    for phrase in forbidden_phrases:
+        assert phrase not in serialized
+
+    assert data["paymentRequirements"]["maxAmountRequired"] == "0"
+    demo_pay_to = "0x" + "0" * 40
+    assert data["paymentRequirements"]["payTo"] == demo_pay_to
+
+
 def test_history_nav_hidden_when_history_explorer_disabled(client):
     original = settings.enable_history_explorer
     try:


### PR DESCRIPTION
## Summary

Adds privacy-safe x402 demand intelligence for SatoshiAPI:

- Adds admin-only `GET /api/v1/analytics/endpoint-backlog`.
- Aggregates usage and x402 payment rows into normalized endpoint patterns.
- Ranks endpoint opportunities by paid use, repeat use, challenge/failure signals, agent demand, estimated revenue, and safe evidence labels.
- Updates x402 info/demo copy so agents are guided toward value-first evaluation instead of blindly attaching payment material.
- Documents the endpoint-demand analytics capability in `docs/SCOPE_OF_WORK.md`.

## Before / After

Before:
- Admin analytics could show traffic, x402 stats, referrers, and funnel pieces, but there was no single ranked answer to: “which endpoint should we improve or build next?”
- Endpoint demand was harder to compare because raw paths, query strings, IDs, wallet-like segments, and payment rows were not normalized into safe aggregate candidates.
- The x402 info/demo copy explained the protocol flow, but was less explicit about low-risk first paid evaluation, safe measurement labels, and avoiding real payment material on the demo endpoint.

After:
- Admins get a backlog-style demand view: endpoint pattern, request count, agent demand, anonymous demand, 402s, 404s, x402 challenges, paid calls, failures, repeat paid actors, estimated revenue, conversion/failure rates, priority/leverage scores, and recommended action.
- Paths are normalized before output: query strings are stripped and address/txid/height/id-like path segments are bucketed.
- The response intentionally does not expose raw IPs, raw user agents, referrers, API key hashes, payment IDs, pay-to addresses, payment proofs, wallet material, private keys, or raw rows.
- x402 info/demo copy now points agents at `/api/v1/fees/landscape` as the recommended first paid evaluation and labels safe measurement fields.
- The demo 402 response remains non-payment/sandbox-oriented and discourages attaching real payment material.

## Validation

Latest post-branch checks:

- `git diff --check` passed.
- `uv run --python 3.12 --extra dev ruff check src/bitcoin_api/routers/analytics.py src/bitcoin_api/routers/status.py src/bitcoin_api/services/analytics.py tests/test_admin.py tests/test_health.py` passed.
- Focused tests passed: `6 passed in 0.05s`.

Earlier broader validation from the same local change set:

- Adjacent admin/health suite: `57 passed in 0.52s`.
- Broad suite excluding known unrelated blockers: `688 passed, 3 skipped, 3 deselected, 1 warning in 5.79s`.
- Full suite still has known unrelated blockers:
  - `tests/test_observatory.py::test_fee_observatory_page`
  - `tests/test_x402_stats.py::test_payment_logger_injection`
  - `tests/test_x402_stats.py::test_payment_logger_exception_safety`

The x402 stats blockers are tied to missing local `bitcoin_api_x402`; the observatory page failure is outside this change.

## Safety / Privacy Notes

- Read-only analytics change; no deploy/restart included.
- No paid x402 request was made during validation.
- Final privacy scan found no raw secrets, API keys, raw IPs, raw user agents, payment signatures, private wallet material, or direct payment-header material in the final diff.
